### PR TITLE
Simplify view and build test foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+__pycache__

--- a/README.md
+++ b/README.md
@@ -43,12 +43,3 @@ import pyblish_lite
 parent = {o.objectName(): o for o in QtGui.qApp.topLevelWidgets()}["MayaWindow"]
 window = pyblish_lite.show(parent)
 ```
-
-<br>
-<br>
-<br>
-
-### Todo
-
-- Reflect changes in GUI when publishing
-- Terminal in which log records are shown

--- a/pyblish_lite/__main__.py
+++ b/pyblish_lite/__main__.py
@@ -13,9 +13,7 @@ if __name__ == '__main__':
         from . import mock
         import pyblish.api
 
-        for Plugin in (mock.MyCollector,
-                       mock.MyValidator,
-                       mock.MyExtractor):
+        for Plugin in mock.plugins:
             pyblish.api.register_plugin(Plugin)
 
     show()

--- a/pyblish_lite/app.css
+++ b/pyblish_lite/app.css
@@ -40,6 +40,7 @@ QListView {
 	background: "transparent"
 }
 
+/* Hide horizontal scrollbars permanently */
 QListView QScrollBar {
 	height: 0px;
 	width: 0px;

--- a/pyblish_lite/app.css
+++ b/pyblish_lite/app.css
@@ -31,6 +31,7 @@ QMenu::item:selected { /* when user selects item using mouse or keyboard */
 }
 
 QDialog {
+	min-width: 300;
 	background: "#555";
 }
 
@@ -39,9 +40,10 @@ QListView {
 	background: "transparent"
 }
 
-/*QListView::item:focus {
+QListView QScrollBar {
+	height: 0px;
+	width: 0px;
 }
-*/
 
 QPushButton {
 	width: 30px;

--- a/pyblish_lite/app.css
+++ b/pyblish_lite/app.css
@@ -34,30 +34,14 @@ QDialog {
 	background: "#555";
 }
 
-QTableView {
+QListView {
 	border: 0px;
-	color: #DDD;
-	selection-background-color: "steelblue";
 	background: "transparent"
 }
 
-QTableView::item:focus {
+/*QListView::item:focus {
 }
-
-QTableView QCheckBox {
-	max-width: 10px;
-}
-
-QTableView QCheckBox::indicator {
-	width: 8px;
-	height: 8px;
-	background: "transparent";
-	border: 1px solid "white";
-}
-
-QTableView QCheckBox::indicator:checked {
-	background: "white";
-}
+*/
 
 QPushButton {
 	width: 30px;

--- a/pyblish_lite/app.css
+++ b/pyblish_lite/app.css
@@ -2,7 +2,7 @@
 
 * {
 	outline: none;
-	color: "white";
+	color: #DDD;
 	font-family: "Open Sans";
 	font-size: 12px;
 	font-weight: 400;
@@ -36,7 +36,7 @@ QDialog {
 
 QTableView {
 	border: 0px;
-	color: "white";
+	color: #DDD;
 	selection-background-color: "steelblue";
 	background: "transparent"
 }

--- a/pyblish_lite/app.py
+++ b/pyblish_lite/app.py
@@ -24,7 +24,7 @@ def install_fonts():
 
     database = QtGui.QFontDatabase()
     for font in ("OpenSans-Regular.ttf",
-                 "OpenSans-SemiBold.ttf"):
+                 "OpenSans-Semibold.ttf"):
         database.addApplicationFont(
             os.path.join(fontdir, font))
 

--- a/pyblish_lite/app.py
+++ b/pyblish_lite/app.py
@@ -9,14 +9,14 @@ from . import control
 
 @contextlib.contextmanager
 def application():
-    app = QtWidgets.qApp.instance()
+    app = QtWidgets.QApplication.instance()
 
     if not app:
         app = QtWidgets.QApplication(sys.argv)
-        yield
+        yield app
         app.exec_()
     else:
-        yield
+        yield app
 
 
 def install_fonts():
@@ -35,12 +35,19 @@ def show(parent=None):
     with open("app.css") as f:
         css = f.read()
 
-    with application():
+    with application() as app:
         install_fonts()
+
+        font = app.font()
+        font.setFamily("Open Sans")
+        font.setPointSize(8)
+        font.setWeight(400)
+
+        app.setFont(font)
+        app.setStyleSheet(css)
 
         window = control.Window(parent)
         window.resize(400, 600)
-        window.setStyleSheet(css)
         window.show()
 
         window.prepare_reset()

--- a/pyblish_lite/compat.py
+++ b/pyblish_lite/compat.py
@@ -22,6 +22,7 @@ def load_pyqt4():
     PyQt4.QtCore.Slot = PyQt4.QtCore.pyqtSlot
     PyQt4.QtCore.Property = PyQt4.QtCore.pyqtProperty
     PyQt4.__binding__ = "PyQt4"
+
     print("Loaded PyQt4")
 
 

--- a/pyblish_lite/control.py
+++ b/pyblish_lite/control.py
@@ -1,3 +1,4 @@
+import os
 import traceback
 
 from Qt import QtCore, QtWidgets, QtGui
@@ -7,8 +8,6 @@ import pyblish.util
 import pyblish.logic
 
 from . import model, view
-
-defer = QtCore.QTimer.singleShot
 
 
 class Window(QtWidgets.QDialog):
@@ -156,7 +155,7 @@ class Window(QtWidgets.QDialog):
             "state": {
                 "context": list(),
                 "plugins": list(),
-                "isRunning": False,
+                "is_running": False,
                 "isClosing": False,
             }
         }
@@ -204,13 +203,14 @@ class Window(QtWidgets.QDialog):
             "ordersWithError": set()
         }
 
+
         for plug, instance in pyblish.logic.Iterator(plugins, context):
             if not plug.active:
                 continue
 
             state["nextOrder"] = plug.order
 
-            if not self.data["state"]["isRunning"]:
+            if not self.data["state"]["is_running"]:
                 raise StopIteration("Stopped")
 
             if test(**state):
@@ -239,10 +239,10 @@ class Window(QtWidgets.QDialog):
             button.hide()
 
         self.data["buttons"]["stop"].show()
-        self.data["state"]["isRunning"] = True
         defer(5, self.publish)
 
     def publish(self):
+        self.data["state"]["is_running"] = True
         models = self.data["models"]
 
         plugins = self.data["state"]["plugins"]
@@ -277,7 +277,11 @@ class Window(QtWidgets.QDialog):
         if error is not None:
             print("An error occurred.\n\n%s" % error)
 
-        self.data["state"]["isRunning"] = False
+        self.data["state"]["is_running"] = False
+
+        plugin_model = self.data["models"]["plugins"]
+        for index in plugin_model:
+            plugin_model.setData(index, model.IsIdle, False)
 
         buttons = self.data["buttons"]
         buttons["reset"].show()
@@ -297,12 +301,13 @@ class Window(QtWidgets.QDialog):
             b.hide()
 
         self.data["buttons"]["stop"].show()
-        self.data["state"]["isRunning"] = True
 
         defer(500, self.reset)
 
     def reset(self):
         """Discover plug-ins and run collection"""
+        self.data["state"]["is_running"] = True
+
         models = self.data["models"]
 
         plugins = pyblish.api.discover()
@@ -363,46 +368,6 @@ class Window(QtWidgets.QDialog):
         if not actions:
             return
 
-        # Context specific actions
-        for action in list(actions):
-            on = action.on
-            if on == "failed" and not index.data(model.HasFailed):
-                actions.remove(action)
-            if on == "succeeded" and not index.data(model.HasSucceeded):
-                actions.remove(action)
-            if on == "processed" and not index.data(model.HasProcessed):
-                actions.remove(action)
-            if on == "notProcessed" and index.data(model.HasProcessed):
-                actions.remove(action)
-
-        # Discard empty groups
-        i = 0
-        try:
-            action = actions[i]
-        except IndexError:
-            pass
-        else:
-            while action:
-                try:
-                    action = actions[i]
-                except IndexError:
-                    break
-
-                isempty = False
-
-                if action.__type__ == "category":
-                    try:
-                        next_ = actions[i + 1]
-                        if next_.__type__ != "action":
-                            isempty = True
-                    except IndexError:
-                        isempty = True
-
-                    if isempty:
-                        actions.pop(i)
-
-                i += 1
-
         menu = QtWidgets.QMenu(self)
         plugin = self.data["models"]["plugins"].items[index.row()]
 
@@ -423,7 +388,7 @@ class Window(QtWidgets.QDialog):
             button.hide()
 
         self.data["buttons"]["stop"].show()
-        self.data["state"]["isRunning"] = True
+        self.data["state"]["is_running"] = True
 
         defer(100, lambda: self.run_action(plugin, action))
 
@@ -443,7 +408,7 @@ class Window(QtWidgets.QDialog):
         if error is not None:
             print("An error occurred.\n\n%s" % error)
 
-        self.data["state"]["isRunning"] = False
+        self.data["state"]["is_running"] = False
 
         buttons = self.data["buttons"]
         buttons["reset"].show()
@@ -478,4 +443,21 @@ class Window(QtWidgets.QDialog):
             del(plugin)
 
         defer(200, self.close)
-        return
+        return event.ignore()
+
+
+def defer(delay, func):
+    """Append artificial delay to `func`
+
+    Arguments:
+        delay (float): Delay multiplier; default 1, 0 means no delay
+        func (callable): Any callable
+
+    """
+
+    delay *= float(os.getenv("PYBLISH_DELAY", 1))
+    if delay > 0:
+        return QtCore.QTimer.singleShot(delay, func)
+    else:
+        return func()
+

--- a/pyblish_lite/mock.py
+++ b/pyblish_lite/mock.py
@@ -48,3 +48,658 @@ class MyExtractor(pyblish.api.InstancePlugin):
 
     def process(self, instance):
         self.log.info("Extracting: %s" % instance)
+
+import os
+import time
+import subprocess
+
+import pyblish.api
+
+
+class CollectRenamed(pyblish.api.Collector):
+    def process(self, context):
+        i = context.create_instance("MyInstanceXYZ", family="MyFamily")
+        i.set_data("name", "My instance")
+
+
+class CollectNegatron(pyblish.api.Collector):
+    """Negative collector adds Negatron"""
+
+    order = pyblish.api.Collector.order - 0.49
+
+    def process_context(self, context):
+        self.log.info("Collecting Negatron")
+        context.create_instance("Negatron", family="MyFamily")
+
+
+class CollectPositron(pyblish.api.Collector):
+    """Positive collector adds Positron"""
+
+    order = pyblish.api.Collector.order + 0.49
+
+    def process_context(self, context):
+        self.log.info("Collecting Positron")
+        context.create_instance("Positron", family="MyFamily")
+
+
+class SelectInstances(pyblish.api.Selector):
+    """Select debugging instances
+
+    These instances are part of the evil plan to destroy the world.
+    Be weary, be vigilant, be sexy.
+
+    """
+
+    def process_context(self, context):
+        self.log.info("Selecting instances..")
+
+        for instance in instances[:-1]:
+            name, data = instance["name"], instance["data"]
+            self.log.info("Selecting: %s" % name)
+            instance = context.create_instance(name)
+
+            for key, value in data.items():
+                instance.set_data(key, value)
+
+
+class SelectDiInstances(pyblish.api.Selector):
+    """Select DI instances"""
+
+    name = "Select Dependency Instances"
+
+    def process(self, context):
+        name, data = instances[-1]["name"], instances[-1]["data"]
+        self.log.info("Selecting: %s" % name)
+        instance = context.create_instance(name)
+
+        for key, value in data.items():
+            instance.set_data(key, value)
+
+
+class SelectInstancesFailure(pyblish.api.Selector):
+    """Select some instances, but fail before adding anything to the context.
+
+    That's right. I'm programmed to fail. Try me.
+
+    """
+
+    __fail__ = True
+
+    def process_context(self, context):
+        self.log.warning("I'm about to fail")
+        assert False, "I was programmed to fail"
+
+
+class SelectInstances2(pyblish.api.Selector):
+    def process(self, context):
+        self.log.warning("I'm good")
+
+
+class ValidateNamespace(pyblish.api.Validator):
+    """Namespaces must be orange
+
+    In case a namespace is not orange, report immediately to
+    your officer in charge, ask for a refund, do a backflip.
+
+    This has been an example of:
+
+    - A long doc-string
+    - With a list
+    - And plenty of newlines and tabs.
+
+    """
+
+    families = ["B"]
+
+    def process(self, instance):
+        self.log.info("Validating the namespace of %s" % instance.data("name"))
+        self.log.info("""And here's another message, quite long, in fact it's
+too long to be displayed in a single row of text.
+But that's how we roll down here. It's got \nnew lines\nas well.
+
+- And lists
+- And more lists
+
+        """)
+
+
+class ValidateContext(pyblish.api.Validator):
+    families = ["A", "B"]
+
+    def process_context(self, context):
+        self.log.info("Processing context..")
+
+
+class ValidateContextFailure(pyblish.api.Validator):
+    optional = True
+    families = ["C"]
+    __fail__ = True
+
+    def process_context(self, context):
+        self.log.info("About to fail..")
+        assert False, """I was programmed to fail
+
+The reason I failed was because the sun was not aligned with the tides,
+and the moon is gray; not yellow. Try again when the moon is yellow."""
+
+
+class Validator1(pyblish.api.Validator):
+    """Test of the order attribute"""
+    order = pyblish.api.Validator.order + 0.1
+    families = ["A"]
+
+    def process_instance(self, instance):
+        pass
+
+
+class Validator2(pyblish.api.Validator):
+    order = pyblish.api.Validator.order + 0.2
+    families = ["B"]
+
+    def process_instance(self, instance):
+        pass
+
+
+class Validator3(pyblish.api.Validator):
+    order = pyblish.api.Validator.order + 0.3
+    families = ["B"]
+
+    def process_instance(self, instance):
+        pass
+
+
+class ValidateFailureMock(pyblish.api.Validator):
+    """Plug-in that always fails"""
+    optional = True
+    order = pyblish.api.Validator.order + 0.1
+    families = ["C"]
+    __fail__ = True
+
+    def process_instance(self, instance):
+        self.log.debug("e = mc^2")
+        self.log.info("About to fail..")
+        self.log.warning("Failing.. soooon..")
+        self.log.critical("Ok, you're done.")
+        assert False, """ValidateFailureMock was destined to fail..
+
+Here's some extended information about what went wrong.
+
+It has quite the long string associated with it, including
+a few newlines and a list.
+
+- Item 1
+- Item 2
+
+"""
+
+
+class ValidateIsIncompatible(pyblish.api.Validator):
+    """This plug-in should never appear.."""
+    requires = False  # This is invalid
+
+
+class ValidateWithRepair(pyblish.api.Validator):
+    """A validator with repair functionality"""
+    optional = True
+    families = ["C"]
+    __fail__ = True
+
+    def process_instance(self, instance):
+        assert False, "%s is invalid, try repairing it!" % instance.name
+
+    def repair_instance(self, instance):
+        self.log.info("Attempting to repair..")
+        self.log.info("Success!")
+
+
+class ValidateWithRepairFailure(pyblish.api.Validator):
+    """A validator with repair functionality that fails"""
+    optional = True
+    families = ["C"]
+    __fail__ = True
+
+    def process_instance(self, instance):
+        assert False, "%s is invalid, try repairing it!" % instance.name
+
+    def repair_instance(self, instance):
+        self.log.info("Attempting to repair..")
+        assert False, "Could not repair due to X"
+
+
+class ValidateWithVeryVeryVeryLongLongNaaaaame(pyblish.api.Validator):
+    """A validator with repair functionality that fails"""
+    families = ["A"]
+
+
+class ValidateWithRepairContext(pyblish.api.Validator):
+    """A validator with repair functionality that fails"""
+    optional = True
+    families = ["C"]
+    __fail__ = True
+
+    def process_context(self, context):
+        assert False, "Could not validate context, try repairing it"
+
+    def repair_context(self, context):
+        self.log.info("Attempting to repair..")
+        assert False, "Could not repair"
+
+
+class ExtractAsMa(pyblish.api.Extractor):
+    """Extract contents of each instance into .ma
+
+    Serialise scene using Maya's own facilities and then put
+    it on the hard-disk. Once complete, this plug-in relies
+    on a Conformer to put it in it's final location, as this
+    extractor merely positions it in the users local temp-
+    directory.
+
+    """
+
+    optional = True
+    __expected__ = {
+        "logCount": ">=4"
+    }
+
+    def process_instance(self, instance):
+        self.log.info("About to extract scene to .ma..")
+        self.log.info("Extraction went well, now verifying the data..")
+
+        if instance.name == "Richard05":
+            self.log.warning("You're almost running out of disk space!")
+
+        self.log.info("About to finish up")
+        self.log.info("Finished successfully")
+
+
+class ConformAsset(pyblish.api.Conformer):
+    """Conform the world
+
+    Step 1: Conform all humans and Step 2: Conform all non-humans.
+    Once conforming has completed, rinse and repeat.
+
+    """
+
+    optional = True
+
+    def process_instance(self, instance):
+        self.log.info("About to conform all humans..")
+
+        if instance.name == "Richard05":
+            self.log.warning("Richard05 is a conformist!")
+
+        self.log.info("About to conform all non-humans..")
+        self.log.info("Conformed Successfully")
+
+
+class ValidateInstancesDI(pyblish.api.Validator):
+    """Validate using the DI interface"""
+    families = ["diFamily"]
+
+    def process(self, instance):
+        self.log.info("Validating %s.." % instance.data("name"))
+
+
+class ValidateDIWithRepair(pyblish.api.Validator):
+    families = ["diFamily"]
+    optional = True
+    __fail__ = True
+
+    def process(self, instance):
+        assert False, "I was programmed to fail, for repair"
+
+    def repair(self, instance):
+        self.log.info("Repairing %s" % instance.data("name"))
+
+
+class ExtractInstancesDI(pyblish.api.Extractor):
+    """Extract using the DI interface"""
+    families = ["diFamily"]
+
+    def process(self, instance):
+        self.log.info("Extracting %s.." % instance.data("name"))
+
+
+class ValidateWithLabel(pyblish.api.Validator):
+    """Validate using the DI interface"""
+    label = "Validate with Label"
+
+
+class ValidateWithLongLabel(pyblish.api.Validator):
+    """Validate using the DI interface"""
+    label = "Validate with Loooooooooooooooooooooong Label"
+
+
+class SimplePlugin1(pyblish.api.Plugin):
+    """Validate using the simple-plugin interface"""
+
+    def process(self):
+        self.log.info("I'm a simple plug-in, only processed once")
+
+
+class SimplePlugin2(pyblish.api.Plugin):
+    """Validate using the simple-plugin interface
+
+    It doesn't have an order, and will likely end up *before* all
+    other plug-ins. (due to how sorted([1, 2, 3, None]) works)
+
+    """
+
+    def process(self, context):
+        self.log.info("Processing the context, simply: %s" % context)
+
+
+class SimplePlugin3(pyblish.api.Plugin):
+    """Simply process every instance"""
+
+    def process(self, instance):
+        self.log.info("Processing the instance, simply: %s" % instance)
+
+
+class ContextAction(pyblish.api.Action):
+    label = "Context action"
+
+    def process(self, context):
+        self.log.info("I have access to the context")
+        self.log.info("Context.instances: %s" % str(list(context)))
+
+
+class FailingAction(pyblish.api.Action):
+    label = "Failing action"
+
+    def process(self):
+        self.log.info("About to fail..")
+        raise Exception("I failed")
+
+
+class LongRunningAction(pyblish.api.Action):
+    label = "Long-running action"
+
+    def process(self):
+        self.log.info("Sleeping for 2 seconds..")
+        time.sleep(2)
+        self.log.info("Ah, that's better")
+
+
+class IconAction(pyblish.api.Action):
+    label = "Icon action"
+    icon = "crop"
+
+    def process(self):
+        self.log.info("I have an icon")
+
+
+class PluginAction(pyblish.api.Action):
+    label = "Plugin action"
+
+    def process(self, plugin):
+        self.log.info("I have access to my parent plug-in")
+        self.log.info("Which is %s" % plugin.id)
+
+
+class LaunchExplorerAction(pyblish.api.Action):
+    label = "Open in Explorer"
+    icon = "folder-open"
+
+    def process(self, context):
+        cwd = os.getcwd()
+        self.log.info("Opening %s in Explorer" % cwd)
+        result = subprocess.call("start .", cwd=cwd, shell=True)
+        self.log.debug(result)
+
+
+class ProcessedAction(pyblish.api.Action):
+    label = "Success action"
+    icon = "check"
+    on = "processed"
+
+    def process(self):
+        self.log.info("I am only available on a successful plug-in")
+
+
+class FailedAction(pyblish.api.Action):
+    label = "Failure action"
+    icon = "close"
+    on = "failed"
+
+
+class SucceededAction(pyblish.api.Action):
+    label = "Success action"
+    icon = "check"
+    on = "succeeded"
+
+    def process(self):
+        self.log.info("I am only available on a successful plug-in")
+
+
+class LongLabelAction(pyblish.api.Action):
+    label = "An incredibly, incredicly looooon label. Very long."
+    icon = "close"
+
+
+class BadEventAction(pyblish.api.Action):
+    label = "Bad event action"
+    on = "not exist"
+
+
+class InactiveAction(pyblish.api.Action):
+    active = False
+
+
+class PluginWithActions(pyblish.api.Validator):
+    optional = True
+    actions = [
+        pyblish.api.Category("General"),
+        ContextAction,
+        FailingAction,
+        LongRunningAction,
+        IconAction,
+        PluginAction,
+        pyblish.api.Category("Empty"),
+        pyblish.api.Category("OS"),
+        LaunchExplorerAction,
+        pyblish.api.Separator,
+        FailedAction,
+        SucceededAction,
+        pyblish.api.Category("Debug"),
+        BadEventAction,
+        InactiveAction,
+        LongLabelAction,
+        pyblish.api.Category("Empty"),
+    ]
+
+    def process(self):
+        self.log.info("Ran PluginWithActions")
+
+
+class FailingPluginWithActions(pyblish.api.Validator):
+    optional = True
+    actions = [
+        FailedAction,
+        SucceededAction,
+    ]
+
+    def process(self):
+        raise Exception("I was programmed to fail")
+
+
+class ValidateDefaultOff(pyblish.api.Validator):
+    families = ["A", "B"]
+    active = False
+    optional = True
+
+    def process(self, instance):
+        self.log.info("Processing instance..")
+
+
+class ValidateWithHyperlinks(pyblish.api.Validator):
+    """To learn about Pyblish
+
+    <a href="http://pyblish.com">click here</a> (http://pyblish.com)
+
+    """
+
+    families = ["A", "B"]
+
+    def process(self, instance):
+        self.log.info("Processing instance..")
+
+        msg = "To learn about Pyblish, <a href='http://pyblish.com'>"
+        msg += "click here</a> (http://pyblish.com)"
+
+        self.log.info(msg)
+
+
+class LongRunningCollector(pyblish.api.Collector):
+    """I will take at least 2 seconds..."""
+    def process(self, context):
+        self.log.info("Sleeping for 2 seconds..")
+        time.sleep(2)
+        self.log.info("Good morning")
+
+
+class LongRunningValidator(pyblish.api.Validator):
+    """I will take at least 2 seconds..."""
+    def process(self, context):
+        self.log.info("Sleeping for 2 seconds..")
+        time.sleep(2)
+        self.log.info("Good morning")
+
+
+class RearrangingPlugin(pyblish.api.ContextPlugin):
+    """Sort plug-ins by family, and then reverse it"""
+    order = pyblish.api.CollectorOrder + 0.2
+
+    def process(self, context):
+        self.log.info("Reversing instances in the context..")
+        context[:] = sorted(
+            context,
+            key=lambda i: i.data["family"],
+            reverse=True
+        )
+        self.log.info("Reversed!")
+
+
+class InactiveInstanceCollectorPlugin(pyblish.api.InstancePlugin):
+    """Special case of an InstancePlugin running as a Collector"""
+    order = pyblish.api.CollectorOrder + 0.1
+    active = False
+
+    def process(self, instance):
+        raise TypeError("I shouldn't have run in the first place")
+
+
+instances = [
+    {
+        "name": "Peter01",
+        "data": {
+            "family": "A",
+            "publish": False
+        }
+    },
+    {
+        "name": "Richard05",
+        "data": {
+            "family": "A",
+        }
+    },
+    {
+        "name": "Steven11",
+        "data": {
+            "family": "B",
+        }
+    },
+    {
+        "name": "Piraya12",
+        "data": {
+            "family": "B",
+        }
+    },
+    {
+        "name": "Marcus",
+        "data": {
+            "family": "C",
+        }
+    },
+    {
+        "name": "Extra1",
+        "data": {
+            "family": "C",
+        }
+    },
+    {
+        "name": "DependencyInstance",
+        "data": {
+            "family": "diFamily"
+        }
+    },
+    {
+        "name": "NoFamily",
+        "data": {}
+    },
+    {
+        "name": "Failure 1",
+        "data": {
+            "family": "failure",
+            "fail": False
+        }
+    },
+    {
+        "name": "Failure 2",
+        "data": {
+            "family": "failure",
+            "fail": True
+        }
+    }
+]
+
+plugins = [
+    MyCollector,
+    MyValidator,
+    MyExtractor,
+
+    CollectRenamed,
+    CollectNegatron,
+    CollectPositron,
+    SelectInstances,
+    SelectInstances2,
+    SelectDiInstances,
+    SelectInstancesFailure,
+    ValidateFailureMock,
+    ValidateNamespace,
+    # ValidateIsIncompatible,
+    ValidateWithVeryVeryVeryLongLongNaaaaame,
+    ValidateContext,
+    ValidateContextFailure,
+    Validator1,
+    Validator2,
+    Validator3,
+    ValidateWithRepair,
+    ValidateWithRepairFailure,
+    ValidateWithRepairContext,
+    ValidateWithLabel,
+    ValidateWithLongLabel,
+    ValidateDefaultOff,
+    ValidateWithHyperlinks,
+    ExtractAsMa,
+    ConformAsset,
+
+    SimplePlugin1,
+    SimplePlugin2,
+    SimplePlugin3,
+
+    ValidateInstancesDI,
+    ExtractInstancesDI,
+    ValidateDIWithRepair,
+
+    PluginWithActions,
+    FailingPluginWithActions,
+
+    LongRunningCollector,
+    LongRunningValidator,
+
+    RearrangingPlugin,
+    InactiveInstanceCollectorPlugin
+]
+
+pyblish.api.sort_plugins(plugins)

--- a/pyblish_lite/mock.py
+++ b/pyblish_lite/mock.py
@@ -17,6 +17,7 @@ class MyOtherAction(pyblish.api.Action):
 
 
 class MyCollector(pyblish.api.ContextPlugin):
+    label = "My Collector"
     order = pyblish.api.CollectorOrder
 
     def process(self, context):
@@ -32,7 +33,7 @@ class MyCollector(pyblish.api.ContextPlugin):
 class MyValidator(pyblish.api.InstancePlugin):
     order = pyblish.api.ValidatorOrder
     active = False
-
+    label = "My Validator"
     actions = [MyAction,
                MyOtherAction]
 
@@ -43,6 +44,7 @@ class MyValidator(pyblish.api.InstancePlugin):
 class MyExtractor(pyblish.api.InstancePlugin):
     order = pyblish.api.ExtractorOrder
     families = ["myFamily"]
+    label = "My Extractor"
 
     def process(self, instance):
         self.log.info("Extracting: %s" % instance)

--- a/pyblish_lite/model.py
+++ b/pyblish_lite/model.py
@@ -29,6 +29,9 @@ class TableModel(QtCore.QAbstractTableModel):
         for index in range(len(self.items)):
             yield self.createIndex(index, 0)
 
+    def data(self, index, role):
+        pass
+
     def append(self, item):
         """Append item to end of model"""
         self.beginInsertRows(QtCore.QModelIndex(),
@@ -71,6 +74,8 @@ class PluginModel(TableModel):
         return super(PluginModel, self).append(item)
 
     def data(self, index, role):
+        super(PluginModel, self).data(index, role)
+
         key = self.schema.get(role)
 
         if key is None:
@@ -121,6 +126,8 @@ class InstanceModel(TableModel):
         return super(InstanceModel, self).append(item)
 
     def data(self, index, role):
+        super(InstanceModel, self).data(index, role)
+
         item = self.items[index.row()]
         key = self.schema.get(role)
 

--- a/pyblish_lite/model.py
+++ b/pyblish_lite/model.py
@@ -16,6 +16,7 @@ Label = QtCore.Qt.DisplayRole + 10
 IsIdle = QtCore.Qt.UserRole + 8
 
 IsChecked = QtCore.Qt.UserRole + 0
+IsOptional = QtCore.Qt.UserRole + 11
 IsProcessing = QtCore.Qt.UserRole + 1
 HasFailed = QtCore.Qt.UserRole + 3
 HasSucceeded = QtCore.Qt.UserRole + 4
@@ -25,7 +26,6 @@ HasProcessed = QtCore.Qt.UserRole + 6
 
 # Available, context-relevant plug-ins
 Actions = QtCore.Qt.UserRole + 2
-
 
 
 class TableModel(QtCore.QAbstractTableModel):
@@ -42,6 +42,7 @@ class TableModel(QtCore.QAbstractTableModel):
             HasSucceeded: "has_succeeded",
             HasFailed: "has_failed",
             Actions: "actions",
+            IsOptional: "optional"
         }
 
     def __iter__(self):
@@ -199,6 +200,7 @@ class InstanceModel(TableModel):
         item.data["has_succeeded"] = False
         item.data["has_failed"] = False
         item.data["is_idle"] = True
+        item.data["optional"] = item.data.get("optional", True)
         item.data["publish"] = item.data.get("publish", True)
         item.data["label"] = item.data.get("label", item.data["name"])
         return super(InstanceModel, self).append(item)

--- a/pyblish_lite/model.py
+++ b/pyblish_lite/model.py
@@ -1,13 +1,14 @@
 from Qt import QtCore, __binding__
 
+Id = QtCore.Qt.UserRole + 7
 Label = QtCore.Qt.DisplayRole
+Actions = QtCore.Qt.UserRole + 2
+IsIdle = QtCore.Qt.UserRole + 8
 IsChecked = QtCore.Qt.UserRole + 0
 IsProcessing = QtCore.Qt.UserRole + 1
-Actions = QtCore.Qt.UserRole + 2
 HasFailed = QtCore.Qt.UserRole + 3
 HasSucceeded = QtCore.Qt.UserRole + 4
 HasProcessed = QtCore.Qt.UserRole + 6
-Id = QtCore.Qt.UserRole + 7
 
 
 class TableModel(QtCore.QAbstractTableModel):
@@ -17,10 +18,12 @@ class TableModel(QtCore.QAbstractTableModel):
 
         # Common schema
         self.schema = {
-            IsProcessing: "isProcessing",
-            HasProcessed: "hasProcessed",
-            HasSucceeded: "hasSucceeded",
-            HasFailed: "hasFailed",
+            Id: "id",
+            IsIdle: "is_idle",
+            IsProcessing: "is_processing",
+            HasProcessed: "has_processed",
+            HasSucceeded: "has_succeeded",
+            HasFailed: "has_failed",
             Actions: "actions",
         }
 
@@ -62,26 +65,75 @@ class PluginModel(TableModel):
         super(PluginModel, self).__init__()
 
         self.schema.update({
-            Label: "__name__",
+            Label: "label",
             IsChecked: "active",
-            Id: "id",
         })
 
     def append(self, item):
-        item.isProcessing = False
-        item.hasSucceeded = False
-        item.hasFailed = False
+        item.is_processing = False
+        item.has_processed = False
+        item.has_succeeded = False
+        item.has_failed = False
+        item.label = item.label or item.__name__
         return super(PluginModel, self).append(item)
 
     def data(self, index, role):
-        super(PluginModel, self).data(index, role)
+        item = self.items[index.row()]
+        key = self.schema.get(role)
+
+        if key is None:
+            return
+
+        if role == Actions:
+            actions = list(item.actions)
+
+            # Context specific actions
+            for action in actions:
+                if action.on == "failed" and not item.has_failed:
+                    actions.remove(action)
+                if action.on == "succeeded" and not item.has_succeeded:
+                    actions.remove(action)
+                if action.on == "processed" and not item.has_processed:
+                    actions.remove(action)
+                if action.on == "notProcessed" and item.has_processed:
+                    actions.remove(action)
+
+            # Discard empty groups
+            i = 0
+            try:
+                action = actions[i]
+            except IndexError:
+                pass
+            else:
+                while action:
+                    try:
+                        action = actions[i]
+                    except IndexError:
+                        break
+
+                    isempty = False
+
+                    if action.__type__ == "category":
+                        try:
+                            next_ = actions[i + 1]
+                            if next_.__type__ != "action":
+                                isempty = True
+                        except IndexError:
+                            isempty = True
+
+                        if isempty:
+                            actions.pop(i)
+
+                    i += 1
+
+            return actions
 
         key = self.schema.get(role)
 
         if key is None:
             return
 
-        return getattr(self.items[index.row()], key, None)
+        return getattr(item, key, None)
 
     def setData(self, index, value, role):
         item = self.items[index.row()]
@@ -119,8 +171,9 @@ class InstanceModel(TableModel):
         })
 
     def append(self, item):
-        item.data["hasSucceeded"] = False
-        item.data["hasFailed"] = False
+        item.data["has_succeeded"] = False
+        item.data["has_failed"] = False
+        item.data["is_idle"] = False
         item.data["publish"] = item.data.get("publish", True)
         item.data["label"] = item.data.get("label", item.data["name"])
         return super(InstanceModel, self).append(item)

--- a/pyblish_lite/view.py
+++ b/pyblish_lite/view.py
@@ -7,6 +7,7 @@ class CheckBoxDelegate(QtWidgets.QStyledItemDelegate):
     toggled = QtCore.Signal("QModelIndex")
 
     def paint(self, painter, option, index):
+        print("painting")
 
         rect = QtCore.QRectF(option.rect)
         rect.setWidth(rect.height())
@@ -47,6 +48,9 @@ class CheckBoxDelegate(QtWidgets.QStyledItemDelegate):
         # Ok, we're done, tidy up.
         painter.restore()
 
+    def sizeHint(self, option, index):
+        return QtCore.QSize(option.rect.width(), 20)
+
     def createEditor(self, parent, option, index):
         """Handle events, such as mousePressEvent"""
         widget = QtWidgets.QWidget(parent)
@@ -64,13 +68,14 @@ class CheckBoxDelegate(QtWidgets.QStyledItemDelegate):
 
     def updateEditorGeometry(self, editor, option, index):
         editor.setGeometry(option.rect)
+        return super(CheckBoxDelegate, self).updateEditorGeometry(
+            editor, option, index)
 
 
 class ItemView(QtWidgets.QListView):
 
     def __init__(self, parent=None):
         super(ItemView, self).__init__(parent)
-
         self.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
 
     def rowsInserted(self, parent, start, end):
@@ -78,3 +83,5 @@ class ItemView(QtWidgets.QListView):
         for row in range(start, end + 1):
             index = self.model().createIndex(row, 0)
             self.openPersistentEditor(index)
+
+        return super(ItemView, self).rowsInserted(parent, start, end)

--- a/pyblish_lite/view.py
+++ b/pyblish_lite/view.py
@@ -15,29 +15,38 @@ class CheckBoxDelegate(QtWidgets.QStyledItemDelegate):
 
         rect = QtCore.QRectF(option.rect)
         rect.setWidth(rect.height())
-        rect.adjust(4, 4, -4, -4)
+        rect.adjust(6, 6, -6, -6)
 
         path = QtGui.QPainterPath()
         path.addRect(rect)
 
+        blue = QtGui.QColor("#99CEEE")
+        green = QtGui.QColor("#77AE24")
+        red = QtGui.QColor("#EE2222")
+
         color = QtCore.Qt.white
 
         if index.data(model.IsProcessing) is True:
-            color = QtCore.Qt.green
+            color = blue
 
         elif index.data(model.HasFailed) is True:
-            color = QtCore.Qt.red
+            color = red
 
         elif index.data(model.HasSucceeded) is True:
-            color = QtCore.Qt.green
+            color = green
+
+        elif index.data(model.HasProcessed) is True:
+            color = green
 
         pen = QtGui.QPen(color, 1)
         font = QtWidgets.QApplication.instance().font()
         metrics = painter.fontMetrics()
 
-        rect = option.rect.adjusted(rect.width() + 10, 2, 0, -2)
+        rect = QtCore.QRectF(option.rect.adjusted(rect.width() + 12, 2, 0, -2))
+        assert rect.width() > 0
+
         label = index.data(model.Label)
-        label = metrics.elidedText(label, QtCore.Qt.ElideRight, rect.width())
+        label = metrics.elidedText(label, QtCore.Qt.ElideRight, rect.width() - 20)
 
         # Maintan reference to state, so we can restore it once we're done
         painter.save()

--- a/pyblish_lite/view.py
+++ b/pyblish_lite/view.py
@@ -20,25 +20,29 @@ class CheckBoxDelegate(QtWidgets.QStyledItemDelegate):
         path = QtGui.QPainterPath()
         path.addRect(rect)
 
-        blue = QtGui.QColor("#99CEEE")
-        green = QtGui.QColor("#77AE24")
         red = QtGui.QColor("#EE2222")
+        green = QtGui.QColor("#77AE24")
+        blue = QtGui.QColor("#99CEEE")
+        fill = False
 
-        color = QtCore.Qt.white
+        check_color = QtCore.Qt.white
 
         if index.data(model.IsProcessing) is True:
-            color = blue
+            check_color = blue
+            fill = True
 
         elif index.data(model.HasFailed) is True:
-            color = red
+            check_color = red
+            fill = True
 
         elif index.data(model.HasSucceeded) is True:
-            color = green
+            check_color = green
+            fill = True
 
         elif index.data(model.HasProcessed) is True:
-            color = green
+            check_color = green
+            fill = True
 
-        pen = QtGui.QPen(color, 1)
         font = QtWidgets.QApplication.instance().font()
         metrics = painter.fontMetrics()
 
@@ -46,21 +50,35 @@ class CheckBoxDelegate(QtWidgets.QStyledItemDelegate):
         assert rect.width() > 0
 
         label = index.data(model.Label)
-        label = metrics.elidedText(label, QtCore.Qt.ElideRight, rect.width() - 20)
+        label = metrics.elidedText(label,
+                                   QtCore.Qt.ElideRight,
+                                   rect.width() - 20)
+
+        font_color = QtGui.QColor("#DDD")
+
+        if not index.data(model.IsChecked):
+            font_color = QtGui.QColor("#888")
 
         # Maintan reference to state, so we can restore it once we're done
         painter.save()
 
         # Draw label
         painter.setFont(font)
+        painter.setPen(QtGui.QPen(font_color))
         painter.drawText(rect, label)
 
         # Draw checkbox
+        pen = QtGui.QPen(check_color, 1)
         painter.setPen(pen)
-        painter.drawPath(path)
 
-        if index.data(model.IsChecked):
-            painter.fillPath(path, color)
+        if index.data(model.IsOptional):
+            painter.drawPath(path)
+
+            if index.data(model.IsChecked):
+                painter.fillPath(path, check_color)
+
+        elif not index.data(model.IsIdle) and index.data(model.IsChecked):
+                painter.fillPath(path, check_color)
 
         # Ok, we're done, tidy up.
         painter.restore()

--- a/pyblish_lite/view.py
+++ b/pyblish_lite/view.py
@@ -7,7 +7,11 @@ class CheckBoxDelegate(QtWidgets.QStyledItemDelegate):
     toggled = QtCore.Signal("QModelIndex")
 
     def paint(self, painter, option, index):
-        print("painting")
+        """Paint checkbox and text
+         _
+        |_|  My label
+
+        """
 
         rect = QtCore.QRectF(option.rect)
         rect.setWidth(rect.height())
@@ -29,14 +33,18 @@ class CheckBoxDelegate(QtWidgets.QStyledItemDelegate):
 
         pen = QtGui.QPen(color, 1)
         font = QtWidgets.QApplication.instance().font()
+        metrics = painter.fontMetrics()
+
+        rect = option.rect.adjusted(rect.width() + 10, 2, 0, -2)
+        label = index.data(model.Label)
+        label = metrics.elidedText(label, QtCore.Qt.ElideRight, rect.width())
 
         # Maintan reference to state, so we can restore it once we're done
         painter.save()
 
-        # Draw text
+        # Draw label
         painter.setFont(font)
-        rect = option.rect.adjusted(rect.width() + 10, 2, 0, -2)
-        painter.drawText(rect, index.data(model.Label))
+        painter.drawText(rect, label)
 
         # Draw checkbox
         painter.setPen(pen)
@@ -76,6 +84,8 @@ class ItemView(QtWidgets.QListView):
 
     def __init__(self, parent=None):
         super(ItemView, self).__init__(parent)
+
+        self.verticalScrollBar().hide()
         self.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
 
     def rowsInserted(self, parent, start, end):

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,0 +1,7 @@
+import sys
+import nose
+
+if __name__ == '__main__':
+    argv = sys.argv[:]
+    argv.extend(['--include=tests', '--verbose'])
+    nose.main(argv=argv)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+# Remove artificial delay from GUI
+os.environ["PYBLISH_DELAY"] = "0"
+
+path = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, path)
+
+from pyblish_lite import compat
+compat.init()
+
+from Qt import QtWidgets
+
+self = sys.modules[__name__]
+self.app = QtWidgets.qApp.instance()
+self.app = self.app or QtWidgets.QApplication(sys.argv)

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -1,0 +1,19 @@
+import pyblish.api
+from pyblish_lite import control
+
+
+def test_something():
+    count = {"#": 0}
+
+    class MyCollector(pyblish.api.ContextPlugin):
+        order = pyblish.api.CollectorOrder
+
+        def process(self, context):
+            count["#"] += 1
+
+    pyblish.api.register_plugin(MyCollector)
+
+    window = control.Window()
+    window.reset()
+
+    assert count["#"] == 1


### PR DESCRIPTION
### Goal

The view used to be a QTableView, where the checkbox was drawn in the first column and the test in the second. The initial idea was that a tableview was a good fit for the additional buttons to the right of each item, like actions.

But it complicated things and I've instead reverted to a delegate handling all drawing, like in Pyblish QML.

The benefit here is that drawing per item is completely in the control of as single function, which means custom things, like checkboxes and animation, is a lot more straightforward.

As a side-effect, this also resolves #6.

#### Tests

I've also laid the groundwork for how tests will work. The idea is that tests shall be automated on Travis for each supported platform and version of Qt, PySide and PyQt respectively. I'd also like to get hosts in there, so far I have docker images for [all major versions of Maya](https://github.com/mottosso/docker-maya) but am not sure how to go about other hosts, such as Nuke which likely requires a license to run headless.