### PR TITLE
Do not modify global QApplication

### DIFF
--- a/pyblish_lite/app.css
+++ b/pyblish_lite/app.css
@@ -3,9 +3,6 @@
 * {
 	outline: none;
 	color: #DDD;
-	font-family: "Open Sans";
-	font-size: 12px;
-	font-weight: 400;
 
 	background-position: center center;
 	background-repeat: no-repeat;

--- a/pyblish_lite/app.py
+++ b/pyblish_lite/app.py
@@ -12,10 +12,12 @@ def application():
     app = QtWidgets.QApplication.instance()
 
     if not app:
+        print("Starting new QApplication..")
         app = QtWidgets.QApplication(sys.argv)
         yield app
         app.exec_()
     else:
+        print("Using existing QApplication..")
         yield app
 
 
@@ -35,20 +37,20 @@ def show(parent=None):
     with open("app.css") as f:
         css = f.read()
 
-    with application() as app:
+    with application():
         install_fonts()
-
-        font = app.font()
-        font.setFamily("Open Sans")
-        font.setPointSize(8)
-        font.setWeight(400)
-
-        app.setFont(font)
-        app.setStyleSheet(css)
 
         window = control.Window(parent)
         window.resize(400, 600)
         window.show()
+
+        font = window.font()
+        font.setFamily("Open Sans")
+        font.setPointSize(8)
+        font.setWeight(400)
+
+        window.setFont(font)
+        window.setStyleSheet(css)
 
         window.prepare_reset()
 

--- a/pyblish_lite/view.py
+++ b/pyblish_lite/view.py
@@ -23,27 +23,26 @@ class CheckBoxDelegate(QtWidgets.QStyledItemDelegate):
         red = QtGui.QColor("#EE2222")
         green = QtGui.QColor("#77AE24")
         blue = QtGui.QColor("#99CEEE")
-        fill = False
 
         check_color = QtCore.Qt.white
 
         if index.data(model.IsProcessing) is True:
             check_color = blue
-            fill = True
 
         elif index.data(model.HasFailed) is True:
             check_color = red
-            fill = True
 
         elif index.data(model.HasSucceeded) is True:
             check_color = green
-            fill = True
 
         elif index.data(model.HasProcessed) is True:
             check_color = green
-            fill = True
 
-        font = QtWidgets.QApplication.instance().font()
+        font = QtGui.QFont()
+        font.setFamily("Open Sans")
+        font.setPointSize(8)
+        font.setWeight(400)
+
         metrics = painter.fontMetrics()
 
         rect = QtCore.QRectF(option.rect.adjusted(rect.width() + 12, 2, 0, -2))


### PR DESCRIPTION
Running within a host, like Maya, caused stylesheet and font to be applied globally. This fixes that.