### PR TITLE
Qt.py and Details popup cosmetics

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+### Contributing To Pyblish Lite
+
+If you would like to contribute code you can do so through GitHub by forking the repository and sending a pull request.
+
+When submitting code, please make every effort to follow existing conventions and style in order to keep the code as readable as possible. Pyblish follows [PEP8](https://www.python.org/dev/peps/pep-0008/) and the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html). Docstrings are written in the [Google Napoleon format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
+
+#### Reporting Bugs
+
+If you report a bug, please ensure to specify the following:
+
+- Description
+- Expected Results
+- Minimal steps to reproduce
+
+#### Requesting or Proposing Features
+
+When specifying a feature, try to format it such that anyone can implement it without necessarily asking you about it.
+
+Include the following:
+
+- Goal
+- Motivation
+- Implementation

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ### Pyblish Lite
 
+[![Build Status](https://travis-ci.org/pyblish/pyblish-lite.svg?branch=master)](https://travis-ci.org/pyblish/pyblish-lite) [![Coverage Status](https://coveralls.io/repos/github/pyblish/pyblish-lite/badge.svg?branch=master)](https://coveralls.io/github/pyblish/pyblish-lite?branch=master)
+
 A lightweight alternative to [pyblish-qml](https://github.com/pyblish/pyblish-qml).
 
 ![untitled](https://cloud.githubusercontent.com/assets/2152766/14935732/054d938c-0ed3-11e6-9468-a3935a0e5184.gif)

--- a/pyblish_lite/__init__.py
+++ b/pyblish_lite/__init__.py
@@ -1,9 +1,7 @@
 from .version import version, version_info, __version__
-from . import compat as __compat
 
 # This must be run prior to importing the application, due to the
 # application requiring a discovered copy of Qt bindings.
-__compat.init()
 
 from .app import show
 

--- a/pyblish_lite/app.css
+++ b/pyblish_lite/app.css
@@ -209,6 +209,7 @@ QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {
 }
 
 #Details {
+	width: 20px;
 	background: #333;
 	border: 1px solid #222;
 }
@@ -227,7 +228,6 @@ QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {
 }
 
 #Details #Heading {
-	padding-left: 7px;  /* Leave space for mouse cursor */
 	font-size: 9pt;
 	font-weight: bold;
 }
@@ -236,9 +236,16 @@ QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {
 	background: transparent;
 }
 
-#Details #Duration {
+#Details #Timestamp {
 	color: #999;
 }
 
-#Details #Docstring {
+#Details #Text {
+	font-family: "Courier";
+	font-size: 9pt;
+}
+
+#Details #Icon {
+	font-family: "FontAwesome";
+	font-size: 15pt;
 }

--- a/pyblish_lite/app.py
+++ b/pyblish_lite/app.py
@@ -4,7 +4,7 @@ import contextlib
 
 from Qt import QtWidgets, QtGui
 
-from . import control, util, window
+from . import control, util, window, compat
 
 
 @contextlib.contextmanager
@@ -47,6 +47,8 @@ def show(parent=None):
         css = css.replace("url(\"", "url(\"%s" % root)
 
     with application():
+        compat.init()
+
         install_fonts()
 
         ctrl = control.Controller()

--- a/pyblish_lite/compat.py
+++ b/pyblish_lite/compat.py
@@ -9,5 +9,6 @@ def __windows_taskbar_compat():
         u"pyblish_lite")
 
 
-if os.name == "nt":
-    __windows_taskbar_compat()
+def init():
+    if os.name == "nt":
+        __windows_taskbar_compat()

--- a/pyblish_lite/compat.py
+++ b/pyblish_lite/compat.py
@@ -1,73 +1,13 @@
 import os
-import sys
 
 
-def load_pyqt5():
-    import PyQt5.Qt
-    sys.modules["Qt"] = PyQt5
-    PyQt5.QtCore.Signal = PyQt5.QtCore.pyqtSignal
-    PyQt5.QtCore.Slot = PyQt5.QtCore.pyqtSlot
-    PyQt5.QtCore.Property = PyQt5.QtCore.pyqtProperty
-
-    # Preserve reference to binding for conditional logic
-    PyQt5.__binding__ = "PyQt5"
-
-    print("Loaded PyQt5")
-
-
-def load_pyqt4():
-    import PyQt4.Qt
-    sys.modules["Qt"] = PyQt4
-    PyQt4.QtWidgets = PyQt4.QtGui
-    PyQt4.QtCore.Signal = PyQt4.QtCore.pyqtSignal
-    PyQt4.QtCore.Slot = PyQt4.QtCore.pyqtSlot
-    PyQt4.QtCore.Property = PyQt4.QtCore.pyqtProperty
-    PyQt4.__binding__ = "PyQt4"
-
-    print("Loaded PyQt4")
-
-
-def load_pyside2():
-    import PySide2
-    sys.modules["Qt"] = PySide2
-    PySide2.__binding__ = "PySide2"
-    print("Loaded PySide2")
-
-
-def load_pyside():
-    import PySide
-    from PySide import QtGui
-    PySide.QtWidgets = QtGui
-    PySide.QtCore.QSortFilterProxyModel = PySide.QtGui.QSortFilterProxyModel
-    sys.modules["Qt"] = PySide
-    PySide.__binding__ = "PySide"
-    print("Loaded PySide")
-
-
-def init():
-    if os.name == "nt":
-        windows_taskbar_compat()
-
-    # Support Qt 4 and 5, PyQt and PySide
-    try:
-        load_pyside2()
-    except ImportError:
-        try:
-            load_pyqt5()
-        except ImportError:
-            try:
-                load_pyside()
-            except ImportError:
-                try:
-                    load_pyqt4()
-                except:
-                    sys.stderr.write("pyblish-lite: Could not find "
-                                     "appropriate bindings for Qt\n")
-
-
-def windows_taskbar_compat():
+def __windows_taskbar_compat():
     """Enable icon and taskbar grouping for Windows 7+"""
 
     import ctypes
     ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(
         u"pyblish_lite")
+
+
+if os.name == "nt":
+    __windows_taskbar_compat()

--- a/pyblish_lite/mock.py
+++ b/pyblish_lite/mock.py
@@ -601,6 +601,14 @@ class InactiveInstanceCollectorPlugin(pyblish.api.InstancePlugin):
         raise TypeError("I shouldn't have run in the first place")
 
 
+class CollectWithIcon(pyblish.api.ContextPlugin):
+    order = pyblish.api.CollectorOrder
+
+    def process(self, context):
+        instance = context.create_instance("With Icon")
+        instance.data["icon"] = u"\uf1c4"
+
+
 instances = [
     {
         "name": "Peter01",
@@ -714,6 +722,7 @@ plugins = [
     InactiveInstanceCollectorPlugin,
 
     CollectComment,
+    CollectWithIcon,
 ]
 
 pyblish.api.sort_plugins(plugins)

--- a/pyblish_lite/model.py
+++ b/pyblish_lite/model.py
@@ -44,6 +44,7 @@ Type = QtCore.Qt.UserRole + 10
 # The display name of an item
 Label = QtCore.Qt.DisplayRole + 0
 Families = QtCore.Qt.DisplayRole + 1
+Icon = QtCore.Qt.DisplayRole + 13
 
 # The item has not been used
 IsIdle = QtCore.Qt.UserRole + 2
@@ -55,8 +56,6 @@ HasFailed = QtCore.Qt.UserRole + 6
 HasSucceeded = QtCore.Qt.UserRole + 7
 HasProcessed = QtCore.Qt.UserRole + 8
 Duration = QtCore.Qt.UserRole + 11
-Expanded = QtCore.Qt.UserRole + 13
-IsExpandable = QtCore.Qt.UserRole + 14
 
 # PLUGINS
 
@@ -128,15 +127,16 @@ class Item(Abstract):
             Id: "id",
             Actions: "actions",
             IsOptional: "optional",
+            Icon: "icon",
 
             # GUI-only data
+            Type: "_type",
             Duration: "_duration",
             IsIdle: "_is_idle",
             IsProcessing: "_is_processing",
             HasProcessed: "_has_processed",
             HasSucceeded: "_has_succeeded",
             HasFailed: "_has_failed",
-            Expanded: "_expanded",
         }
 
     def store_checkstate(self):
@@ -179,8 +179,7 @@ class Plugin(Item):
         item._has_processed = False
         item._has_succeeded = False
         item._has_failed = False
-        item._expanded = False
-        item._is_expandable = False
+        item._type = "plugin"
 
         return super(Plugin, self).append(item)
 
@@ -295,11 +294,10 @@ class Instance(Item):
         item.data["label"] = item.data.get("label", item.data["name"])
 
         # GUI-only data
+        item.data["_type"] = "instance"
         item.data["_has_succeeded"] = False
         item.data["_has_failed"] = False
         item.data["_is_idle"] = True
-        item.data["_expanded"] = False
-        item.data["_is_expandable"] = False
 
         # Merge `family` and `families` for backwards compatibility
         item.data["__families__"] = ([item.data["family"]] +
@@ -380,18 +378,7 @@ class Terminal(Abstract):
             ExcLineNumber: "line_number",
             ExcFunc: "func",
             ExcExc: "exc",
-
-            # GUI-only data
-            Expanded: "_expanded",
-            IsExpandable: "_is_expandable",
         }
-
-    def append(self, item):
-        # GUI-only data
-        item["_expanded"] = False
-        item["_is_expandable"] = item.get("_is_expandable", False)
-
-        return super(Terminal, self).append(item)
 
     def data(self, index, role):
         item = self.items[index.row()]
@@ -440,9 +427,6 @@ class Terminal(Abstract):
                 "msg": record.msg,
                 "msecs": record.msecs,
                 "levelname": record.levelname,
-
-                # GUI-only data
-                "_is_expandable": True,
             })
 
         error = result["error"]
@@ -455,9 +439,6 @@ class Terminal(Abstract):
                 "line_number": line_no,
                 "func": func,
                 "exc": exc,
-
-                # GUI-only data
-                "_is_expandable": True
             })
 
 

--- a/pyblish_lite/view.py
+++ b/pyblish_lite/view.py
@@ -5,8 +5,8 @@ class Item(QtWidgets.QListView):
     # An item is requesting to be toggled, with optional forced-state
     toggled = QtCore.Signal("QModelIndex", object)
 
-    # An item is requesting details, True means show, False means hide
-    inspected = QtCore.Signal("QModelIndex", bool)
+    # An item is requesting details
+    inspected = QtCore.Signal("QModelIndex")
 
     def __init__(self, parent=None):
         super(Item, self).__init__(parent)
@@ -17,8 +17,6 @@ class Item(QtWidgets.QListView):
         self.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
         self.setResizeMode(QtWidgets.QListView.Adjust)
         self.setVerticalScrollMode(QtWidgets.QListView.ScrollPerPixel)
-
-        self._inspecting = False
 
     def event(self, event):
         if not event.type() == QtCore.QEvent.KeyPress:
@@ -51,37 +49,27 @@ class Item(QtWidgets.QListView):
         self._inspecting = False
         super(Item, self).leaveEvent(event)
 
-    def mouseMoveEvent(self, event):
-        if self._inspecting:
-            index = self.indexAt(event.pos())
-            self.inspected.emit(index, True) if index.isValid() else None
-
-        return super(Item, self).mouseMoveEvent(event)
-
     def mousePressEvent(self, event):
-        self._inspecting = event.button() == QtCore.Qt.MidButton
+        if event.button() == QtCore.Qt.MidButton:
+            index = self.indexAt(event.pos())
+            self.inspected.emit(index) if index.isValid() else None
+
         return super(Item, self).mousePressEvent(event)
 
     def mouseReleaseEvent(self, event):
         if event.button() == QtCore.Qt.LeftButton:
             indexes = self.selectionModel().selectedIndexes()
-            if len(indexes) <= 1:
+            if len(indexes) <= 1 and event.pos().x() < 20:
                 for index in indexes:
                     self.toggled.emit(index, None)
-
-        if event.button() == QtCore.Qt.MidButton:
-            index = self.indexAt(event.pos())
-            self.inspected.emit(index, False) if index.isValid() else None
-            self._inspecting = False
 
         return super(Item, self).mouseReleaseEvent(event)
 
 
 class LogView(QtWidgets.QListView):
 
-    # Expand an item, defaults to (None) toggling currently active state.
-    # Force a state via True or False.
-    expanded = QtCore.Signal("QModelIndex", object)
+    # An item is requesting details
+    inspected = QtCore.Signal("QModelIndex")
 
     def __init__(self, parent=None):
         super(LogView, self).__init__(parent)
@@ -92,12 +80,19 @@ class LogView(QtWidgets.QListView):
         self.setSelectionMode(QtWidgets.QListView.ExtendedSelection)
         self.setVerticalScrollMode(QtWidgets.QListView.ScrollPerPixel)
 
+    def mousePressEvent(self, event):
+        if event.button() == QtCore.Qt.MidButton:
+            index = self.indexAt(event.pos())
+            self.inspected.emit(index) if index.isValid() else None
+
+        return super(LogView, self).mousePressEvent(event)
+
     def mouseReleaseEvent(self, event):
         if event.button() == QtCore.Qt.LeftButton:
             indexes = self.selectionModel().selectedIndexes()
-            if len(indexes) <= 1:
+            if len(indexes) <= 1 and event.pos().x() < 20:
                 for index in indexes:
-                    self.expanded.emit(index, None)
+                    self.toggled.emit(index, None)
 
         return super(LogView, self).mouseReleaseEvent(event)
 
@@ -119,31 +114,46 @@ class LogView(QtWidgets.QListView):
 
 
 class Details(QtWidgets.QDialog):
+    """Popup dialog with detailed information
+     _____________________________________
+    |                                     |
+    | Header                    Timestamp |
+    | Subheading                          |
+    |                                     |
+    |-------------------------------------|
+    |                                     |
+    | Text                                |
+    |_____________________________________|
+
+    """
+
     def __init__(self, parent=None):
         super(Details, self).__init__(parent)
-        self.setWindowFlags(QtCore.Qt.ToolTip)
+        self.setWindowFlags(QtCore.Qt.Popup)
+        self.setEnabled(False)
 
         header = QtWidgets.QWidget()
 
-        label = QtWidgets.QLabel("My Instance")
-        families = QtWidgets.QLabel("default, cfx, simRig")
-        duration = QtWidgets.QLabel("255 ms")
-        spacer = QtWidgets.QWidget()
+        icon = QtWidgets.QLabel()
+        heading = QtWidgets.QLabel()
+        subheading = QtWidgets.QLabel()
+        timestamp = QtWidgets.QLabel()
+        timestamp.setFixedWidth(50)
 
         layout = QtWidgets.QGridLayout(header)
-        layout.addWidget(label, 0, 0)
-        layout.addWidget(families, 1, 0)
-        layout.addWidget(spacer, 0, 1)
-        layout.addWidget(duration, 0, 2)
+        layout.addWidget(icon, 0, 0)
+        layout.addWidget(heading, 0, 1)
+        layout.addWidget(timestamp, 0, 2)
+        layout.addWidget(subheading, 1, 0, 1, -1)
         layout.setColumnStretch(1, 1)
         layout.setContentsMargins(5, 5, 5, 5)
 
         body = QtWidgets.QWidget()
 
-        docstring = QtWidgets.QLabel("Hello World")
+        text = QtWidgets.QLabel()
 
         layout = QtWidgets.QVBoxLayout(body)
-        layout.addWidget(docstring)
+        layout.addWidget(text)
         layout.setContentsMargins(5, 5, 5, 5)
 
         layout = QtWidgets.QVBoxLayout(self)
@@ -158,32 +168,39 @@ class Details(QtWidgets.QDialog):
 
         names = {
             # Main
+            "Icon": icon,
             "Header": header,
 
-            "Heading": label,
-            "Subheading": families,
-            "Duration": duration,
+            "Heading": heading,
+            "Subheading": subheading,
+            "Timestamp": timestamp,
 
             "Body": body,
-            "Docstring": docstring,
+            "Text": text,
         }
 
         for name, widget in names.items():
             widget.setObjectName(name)
 
-    def init(self, data):
-        for widget, key in {"Heading": "label",
-                            "Subheading": "families",
-                            "Duration": "duration",
-                            "Docstring": "docstring"}.items():
+    def show(self, data):
+        # Open before initializing; this allows the widget to properly
+        # size itself before filling it with content. The content can
+        # then elide itself properly.
+
+        for widget, key in {"Icon": "icon",
+                            "Heading": "heading",
+                            "Subheading": "subheading",
+                            "Timestamp": "timestamp",
+                            "Text": "text"}.items():
             widget = self.findChild(QtWidgets.QWidget, widget)
-            value = data[key]
+            value = data.get(key, "")
 
-            value = widget.fontMetrics().elidedText(value,
-                                                    QtCore.Qt.ElideRight,
-                                                    widget.width())
+            if key != "text":
+                value = widget.fontMetrics().elidedText(value,
+                                                        QtCore.Qt.ElideRight,
+                                                        widget.width())
             widget.setText(value)
+            widget.updateGeometry()
 
-    def leaveEvent(self, event):
-        self.hide()
-        return super(Details, self).leaveEvent(event)
+        self.updateGeometry()
+        self.setVisible(True)

--- a/pyblish_lite/view.py
+++ b/pyblish_lite/view.py
@@ -131,6 +131,7 @@ class Details(QtWidgets.QDialog):
         super(Details, self).__init__(parent)
         self.setWindowFlags(QtCore.Qt.Popup)
         self.setEnabled(False)
+        self.setFixedWidth(100)
 
         header = QtWidgets.QWidget()
 
@@ -144,13 +145,14 @@ class Details(QtWidgets.QDialog):
         layout.addWidget(icon, 0, 0)
         layout.addWidget(heading, 0, 1)
         layout.addWidget(timestamp, 0, 2)
-        layout.addWidget(subheading, 1, 0, 1, -1)
+        layout.addWidget(subheading, 1, 1, 1, -1)
         layout.setColumnStretch(1, 1)
         layout.setContentsMargins(5, 5, 5, 5)
 
         body = QtWidgets.QWidget()
 
         text = QtWidgets.QLabel()
+        text.setWordWrap(True)
 
         layout = QtWidgets.QVBoxLayout(body)
         layout.addWidget(text)

--- a/pyblish_lite/window.py
+++ b/pyblish_lite/window.py
@@ -599,7 +599,7 @@ class Window(QtWidgets.QDialog):
                 "icon": index.data(model.Icon) or u"\uf0b0",  # fa-filter
                 "heading": index.data(model.Label),
                 "subheading": ", ".join(index.data(model.Families)),
-                "text": (index.data(model.Docstring) or "").split("\n")[0],
+                "text": index.data(model.Docstring) or "",
                 "timestamp": str(index.data(model.Duration) or 0) + " ms",
             })
 
@@ -608,7 +608,7 @@ class Window(QtWidgets.QDialog):
                 "icon": index.data(model.Icon) or u"\uf15b",  # fa-file
                 "heading": index.data(model.Label),
                 "subheading": ", ".join(index.data(model.Families)),
-                "text": "Some text",
+                "text": "",
                 "timestamp": str(index.data(model.Duration) or 0) + " ms",
             })
 

--- a/pyblish_lite/window.py
+++ b/pyblish_lite/window.py
@@ -428,6 +428,14 @@ class Window(QtWidgets.QDialog):
                 "plugins": plugin_model,
                 "terminal": terminal_model,
             },
+            "terminal_toggles": {
+                "record": show_records,
+                "debug": show_debug,
+                "info": show_info,
+                "warning": show_warning,
+                "error": show_error,
+                "critical": show_critical
+            },
             "tabs": {
                 "artist": artist_tab,
                 "overview": overview_tab,
@@ -495,11 +503,14 @@ class Window(QtWidgets.QDialog):
                                             QtCore.Qt.DirectConnection)
 
         artist_view.toggled.connect(self.on_item_toggled)
-        left_view.inspected.connect(self.on_item_inspected)
-        right_view.inspected.connect(self.on_item_inspected)
         left_view.toggled.connect(self.on_item_toggled)
         right_view.toggled.connect(self.on_item_toggled)
-        terminal_view.expanded.connect(self.on_item_expanded)
+
+        artist_view.inspected.connect(self.on_item_inspected)
+        left_view.inspected.connect(self.on_item_inspected)
+        right_view.inspected.connect(self.on_item_inspected)
+        terminal_view.inspected.connect(self.on_item_inspected)
+
         reset.clicked.connect(self.on_reset_clicked)
         validate.clicked.connect(self.on_validate_clicked)
         play.clicked.connect(self.on_play_clicked)
@@ -539,19 +550,67 @@ class Window(QtWidgets.QDialog):
 
         index.model().setData(index, state, model.Expanded)
 
-    def on_item_inspected(self, index, state):
+    def on_item_inspected(self, index):
         details = self.data["modals"]["details"]
+        details.move(QtGui.QCursor.pos())
 
-        if state is True:
-            details.move(QtGui.QCursor.pos())
-            details.init({
-                "label": index.data(model.Label),
-                "families": ", ".join(index.data(model.Families)),
-                "duration": str(index.data(model.Duration) or 0) + " ms",
-                "docstring": (index.data(model.Docstring) or "").split("\n")[0]
+        if index.data(model.Type) == "record":
+
+            # Compose available data
+            data = list()
+            for key, value in index.data(model.Data).items():
+                if key.startswith("_"):
+                    continue
+
+                data.append("%s %s" % ((key + ":").ljust(12), value))
+
+            text = "\n".join(data)
+
+            details.show({
+                "icon": u"\uf111",  # fa-circle
+                "heading": index.data(model.Label).split("\n")[0],
+                "subheading": "LogRecord (%s)" % index.data(model.LogLevel),
+                "text": text,
+                "timestamp": "",
             })
 
-        details.setVisible(state)
+        elif index.data(model.Type) == "error":
+
+            # Compose available data
+            data = list()
+            for key, value in index.data(model.Data).items():
+                if key.startswith("_"):
+                    continue
+
+                data.append("%s %s" % ((key + ":").ljust(12), value))
+
+            text = "\n".join(data)
+
+            details.show({
+                "icon": u"\uf071",  # fa-exclamation-triangle
+                "heading": index.data(model.Label).split("\n")[0],
+                "subheading": "Exception",
+                "text": text,
+                "timestamp": "",
+            })
+
+        elif index.data(model.Type) == "plugin":
+            details.show({
+                "icon": index.data(model.Icon) or u"\uf0b0",  # fa-filter
+                "heading": index.data(model.Label),
+                "subheading": ", ".join(index.data(model.Families)),
+                "text": (index.data(model.Docstring) or "").split("\n")[0],
+                "timestamp": str(index.data(model.Duration) or 0) + " ms",
+            })
+
+        elif index.data(model.Type) == "instance":
+            details.show({
+                "icon": index.data(model.Icon) or u"\uf15b",  # fa-file
+                "heading": index.data(model.Label),
+                "subheading": ", ".join(index.data(model.Families)),
+                "text": "Some text",
+                "timestamp": str(index.data(model.Duration) or 0) + " ms",
+            })
 
     def on_item_toggled(self, index, state=None):
         """An item is requesting to be toggled"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pyblish-base>=1.4
 PySide>=1.2
+Qt>=0.2.0


### PR DESCRIPTION

This PR moves the Qt binding wrapper to its own repository as a dependency.

- https://github.com/mottosso/Qt

It also adds middle-click details to all panels, including the Terminal which replaces the fold-out view.

![untitled](https://cloud.githubusercontent.com/assets/2152766/15644850/38d4d418-264d-11e6-92a7-659f09451d27.gif)