### PR TITLE
Update requirements.txt, remove doctest from Qt.py

### DIFF
--- a/pyblish_lite/vendor/Qt.py
+++ b/pyblish_lite/vendor/Qt.py
@@ -9,12 +9,12 @@ Resolution order:
     - PyQt4
 
 Usage:
-    >>> import sys
-    >>> from Qt import QtWidgets
-    >>> app = QtWidgets.QApplication(sys.argv)
-    >>> button = QtWidgets.QPushButton("Hello World")
-    >>> button.show()
-    >>> app.exec_()
+    >> import sys
+    >> from Qt import QtWidgets
+    >> app = QtWidgets.QApplication(sys.argv)
+    >> button = QtWidgets.QPushButton("Hello World")
+    >> button.show()
+    >> app.exec_()
 
 """
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 pyblish-base>=1.4
 PySide>=1.2
-Qt.py>=0.2.1

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 import pyblish_lite
+from pyblish_lite.vendor import Qt
 from Qt import QtCore
 
 # Remove artificial delay from GUI


### PR DESCRIPTION
Travis automatically includes doctests, but it can't run anything that involves QApplication. Qt.py has a doctest that uses this, this PR disables that.