### PR TITLE
Enable orders below 0

### DIFF
--- a/pyblish_lite/control.py
+++ b/pyblish_lite/control.py
@@ -134,13 +134,12 @@ class Controller(QtCore.QObject):
 
         return result
 
-    def _run(self, until=-1, on_finished=lambda: None):
+    def _run(self, until=float("inf"), on_finished=lambda: None):
         """Process current pair and store next pair for next process
 
         Arguments:
             until (pyblish.api.Order, optional): Keep fetching next()
-                until this order, default value -1 means it will run
-                until there are no more plug-ins.
+                until this order, default value is infinity.
             on_finished (callable, optional): What to do when finishing,
                 defaults to doing nothing.
 
@@ -158,7 +157,8 @@ class Controller(QtCore.QObject):
             #
             # TODO(marcus): Make this less magical
             #
-            if until != -1 and self.current_pair[0].order > (until + 0.5):
+            order = self.current_pair[0].order
+            if order > (until + 0.5):
                 return util.defer(100, on_finished)
 
             self.about_to_process.emit(*self.current_pair)

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -273,3 +273,36 @@ def test_order_20():
     ctrl.publish()
 
     assert count["#"] == 111, count
+
+
+@with_setup(clean)
+def test_far_negative_orders():
+    """Orders may go below 0"""
+
+    count = {"#": 0}
+
+    class MyCollector1(pyblish.api.ContextPlugin):
+        order = pyblish.api.CollectorOrder
+
+    class MyCollector2(pyblish.api.ContextPlugin):
+        order = -1
+
+    class MyCollector3(pyblish.api.ContextPlugin):
+        order = -1000
+
+    def process(self, context):
+        count["#"] += 1
+
+    MyCollector1.process = process
+    MyCollector2.process = process
+    MyCollector3.process = process
+
+    pyblish.api.register_plugin(MyCollector1)
+    pyblish.api.register_plugin(MyCollector2)
+    pyblish.api.register_plugin(MyCollector3)
+
+    ctrl = control.Controller()
+    ctrl.reset()
+
+    # They all register as Collectors
+    assert count["#"] == 3, count


### PR DESCRIPTION
Before, the `_run()` function of control.py assumed `-1` as the catch-all value for processes that should never stop until finished.

But it begged for a future occasion where someone had orders from `-2 to 0` in which case their plug-in at exact `-1` would not get run.

This method, `float("inf")`, should be more resilient to such cornercases.