### PR TITLE
Sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 cover
 .coverage
 build
+.idea/

--- a/pyblish_lite/app.css
+++ b/pyblish_lite/app.css
@@ -37,6 +37,11 @@ QListView {
 	background: "transparent"
 }
 
+QTreeView {
+	border: 0px;
+	background: "transparent"
+}
+
 QPushButton {
 	width: 27px;
 	height: 27px;

--- a/pyblish_lite/delegate.py
+++ b/pyblish_lite/delegate.py
@@ -119,6 +119,66 @@ class Item(QtWidgets.QStyledItemDelegate):
         return QtCore.QSize(option.rect.width(), 20)
 
 
+class Section(QtWidgets.QStyledItemDelegate):
+    """Generic delegate for section header"""
+
+    def paint(self, painter, option, index):
+        """Paint text
+         _
+        My label
+
+        """
+
+        body_rect = QtCore.QRectF(option.rect)
+
+        metrics = painter.fontMetrics()
+
+        label_rect = QtCore.QRectF(option.rect.adjusted(0, 2, 0, -2))
+
+        assert label_rect.width() > 0
+
+        label = index.data(model.Label)
+        label = metrics.elidedText(label,
+                                   QtCore.Qt.ElideRight,
+                                   label_rect.width())
+
+        font_color = colors["idle"]
+        if not index.data(model.IsChecked):
+            font_color = colors["inactive"]
+
+        # Maintain reference to state, so we can restore it once we're done
+        painter.save()
+
+        # Draw label
+        painter.setFont(fonts["h4"])
+        painter.setPen(QtGui.QPen(font_color))
+        painter.drawText(label_rect, label)
+
+        if option.state & QtWidgets.QStyle.State_MouseOver:
+            painter.fillRect(body_rect, colors["hover"])
+
+        if option.state & QtWidgets.QStyle.State_Selected:
+            painter.fillRect(body_rect, colors["selected"])
+
+        # Ok, we're done, tidy up.
+        painter.restore()
+
+    def sizeHint(self, option, index):
+        return QtCore.QSize(option.rect.width(), 20)
+
+
+class ItemAndSection(Item):
+    """Generic delegate for model items in proxy tree view"""
+    def paint(self, painter, option, index):
+
+        model = index.model()
+        if model.is_header(index):
+            Section().paint(painter, option, index)
+            return
+
+        super(ItemAndSection, self).paint(painter, option, index)
+
+
 class Artist(QtWidgets.QStyledItemDelegate):
     """Delegate used on Artist page"""
 

--- a/pyblish_lite/model.py
+++ b/pyblish_lite/model.py
@@ -46,6 +46,7 @@ Type = QtCore.Qt.UserRole + 10
 Label = QtCore.Qt.DisplayRole + 0
 Families = QtCore.Qt.DisplayRole + 1
 Icon = QtCore.Qt.DisplayRole + 13
+Order = QtCore.Qt.UserRole + 62
 
 # The item has not been used
 IsIdle = QtCore.Qt.UserRole + 2
@@ -129,6 +130,7 @@ class Item(Abstract):
             Actions: "actions",
             IsOptional: "optional",
             Icon: "icon",
+            Order: "order",
 
             # GUI-only data
             Type: "_type",

--- a/pyblish_lite/tree.py
+++ b/pyblish_lite/tree.py
@@ -1,0 +1,278 @@
+
+from .vendor import Qt
+from Qt import QtWidgets, QtCore
+from itertools import groupby
+
+
+class Item(object):
+    """Base class for an Item in the Group By Proxy"""
+    def __init__(self):
+        self._parent = None
+        self._children = list()
+
+    def parent(self):
+        return self._parent
+
+    def addChild(self, node):
+        node._parent = self
+        self._children.append(node)
+
+    def rowCount(self):
+        return len(self._children)
+
+    def row(self):
+
+        parent = self.parent()
+        if not parent:
+            return 0
+        else:
+            return self.parent().children().index(self)
+
+    def columnCount(self):
+        return 1
+
+    def child(self, row):
+        return self._children[row]
+
+    def children(self):
+        return self._children
+
+    def data(self, role=QtCore.Qt.DisplayRole):
+        return None
+
+
+class ProxyItem(Item):
+    def __init__(self, source_index):
+        super(ProxyItem, self).__init__()
+        self.source_index = source_index
+
+    def data(self, role=QtCore.Qt.DisplayRole):
+        return self.source_index.data(role)
+
+
+class ProxySectionItem(Item):
+    def __init__(self, label):
+        super(ProxySectionItem, self).__init__()
+        self.label = "{0}".format(label)
+
+    def data(self, role=QtCore.Qt.DisplayRole):
+
+        if role == QtCore.Qt.DisplayRole:
+            return self.label
+
+        elif role == QtCore.Qt.FontRole:
+            font = QtWidgets.QFont()
+            font.setPointSize(10)
+            font.setWeight(900)
+            return font
+
+        elif role == QtCore.Qt.TextColorRole:
+            return QtWidgets.QColor(50, 20, 20)
+
+        elif role == QtCore.Qt.BackgroundColorRole:
+            return QtWidgets.QColor(220, 220, 220)
+
+
+class Proxy(QtWidgets.QAbstractProxyModel):
+    """Proxy that groups by based on a specific role
+
+    This assumes the source data is a flat list and not a tree.
+
+    """
+
+    def __init__(self):
+        super(Proxy, self).__init__()
+        self.root = Item()
+        self.group_role = QtCore.Qt.DisplayRole
+
+    def set_group_role(self, role):
+        self.group_role = role
+
+    def rebuild(self):
+        """Update proxy sections and items
+
+        This should be called after changes in the source model that require
+        changes in this list (for example new indices, less indices or update
+        sections)
+
+        """
+
+        # Start with new root node
+        self.root = Item()
+
+        # Get indices from source model
+        source = self.sourceModel()
+        source_rows = source.rowCount()
+        source_indices = [source.index(i, 0) for i in range(source_rows)]
+
+        def key_getter(source_index):
+            """Return group role data for source index"""
+            return source.data(source_index, self.group_role)
+
+        for section, group in groupby(source_indices, key=key_getter):
+
+            # section
+            section_item = ProxySectionItem(section)
+            self.root.addChild(section_item)
+
+            #  items in section
+            for i, index in enumerate(group):
+                proxy_item = ProxyItem(index)
+                section_item.addChild(proxy_item)
+
+    def data(self, index, role=QtCore.Qt.DisplayRole):
+
+        if not index.isValid():
+            return
+
+        node = index.internalPointer()
+
+        if not node:
+            return
+
+        return node.data(role)
+
+    def is_header(self, index):
+        """Return whether index is a header"""
+        if index in self.to_source:
+            return False
+        else:
+            return True
+
+    def mapFromSource(self, index):
+
+        for section_item in self.root.children():
+            for item in section_item.children():
+                if item.source_index == index:
+                    return self.createIndex(item.row(),
+                                            index.column(),
+                                            item)
+
+        return QtCore.QModelIndex()
+
+    def mapToSource(self, index):
+
+        if not index.isValid():
+            return QtCore.QModelIndex()
+
+        node = index.internalPointer()
+        if not node:
+            return QtCore.QModelIndex()
+
+        if not hasattr(node, "source_index"):
+            return QtCore.QModelIndex()
+
+        return node.source_index
+
+    def columnCount(self, parent=QtCore.QModelIndex()):
+        return 1
+
+    def rowCount(self, parent):
+
+        if not parent.isValid():
+            node = self.root
+        else:
+            node = parent.internalPointer()
+
+        if not node:
+            return 0
+
+        return node.rowCount()
+
+    def index(self, row, column, parent):
+
+        if parent and parent.isValid():
+            parent_node = parent.internalPointer()
+        else:
+            parent_node = self.root
+
+        item = parent_node.child(row)
+        if item:
+            return self.createIndex(row, column, item)
+        else:
+            return QtCore.QModelIndex()
+
+    def parent(self, index):
+
+        if not index.isValid():
+            return QtCore.QModelIndex()
+
+        node = index.internalPointer()
+        if not node:
+            return QtCore.QModelIndex()
+        else:
+            parent = node.parent()
+            if not parent:
+                return QtCore.QModelIndex()
+
+            row = parent.row()
+            return self.createIndex(row, 0, parent)
+
+
+class View(QtWidgets.QTreeView):
+    # An item is requesting to be toggled, with optional forced-state
+    toggled = QtCore.Signal("QModelIndex", object)
+
+    # An item is requesting details
+    inspected = QtCore.Signal("QModelIndex")
+
+    def __init__(self, parent=None):
+        super(View, self).__init__(parent)
+
+        self.horizontalScrollBar().hide()
+        self.viewport().setAttribute(QtCore.Qt.WA_Hover, True)
+        self.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+        self.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
+        #self.setResizeMode(QtWidgets.QTreeView.Adjust)
+        self.setVerticalScrollMode(QtWidgets.QTreeView.ScrollPerPixel)
+        self.setHeaderHidden(True)
+        self.setRootIsDecorated(False)
+        self.setIndentation(10)
+        #self.setItemsExpandable(False)
+
+    def event(self, event):
+        if not event.type() == QtCore.QEvent.KeyPress:
+            return super(View, self).event(event)
+
+        elif event.key() == QtCore.Qt.Key_Space:
+            for index in self.selectionModel().selectedIndexes():
+                self.toggled.emit(index, None)
+
+            return True
+
+        elif event.key() == QtCore.Qt.Key_Backspace:
+            for index in self.selectionModel().selectedIndexes():
+                self.toggled.emit(index, False)
+
+            return True
+
+        elif event.key() == QtCore.Qt.Key_Return:
+            for index in self.selectionModel().selectedIndexes():
+                self.toggled.emit(index, True)
+
+            return True
+
+        return super(View, self).event(event)
+
+    def focusOutEvent(self, event):
+        self.selectionModel().clear()
+
+    def leaveEvent(self, event):
+        self._inspecting = False
+        super(View, self).leaveEvent(event)
+
+    def mousePressEvent(self, event):
+        if event.button() == QtCore.Qt.MidButton:
+            index = self.indexAt(event.pos())
+            self.inspected.emit(index) if index.isValid() else None
+
+        return super(View, self).mousePressEvent(event)
+
+    def mouseReleaseEvent(self, event):
+        if event.button() == QtCore.Qt.LeftButton:
+            indexes = self.selectionModel().selectedIndexes()
+            if len(indexes) <= 1 and event.pos().x() < 20:
+                for index in indexes:
+                    self.toggled.emit(index, None)
+
+        return super(View, self).mouseReleaseEvent(event)

--- a/pyblish_lite/window.py
+++ b/pyblish_lite/window.py
@@ -136,7 +136,7 @@ class Window(QtWidgets.QDialog):
         left_view = tree.View()
         right_view = tree.View()
 
-        item_delegate = delegate.Item()
+        item_delegate = delegate.ItemAndSection()
         left_view.setItemDelegate(item_delegate)
         right_view.setItemDelegate(item_delegate)
 
@@ -358,7 +358,7 @@ class Window(QtWidgets.QDialog):
 
         artist_view.setModel(instance_model)
 
-        left_proxy = tree.Proxy()
+        left_proxy = tree.FamilyGroupProxy()
         left_proxy.setSourceModel(instance_model)
         left_proxy.set_group_role(model.Families)
         left_view.setModel(left_proxy)
@@ -504,11 +504,23 @@ class Window(QtWidgets.QDialog):
         controller.was_acted.connect(left_proxy.rebuild)
         controller.finished.connect(left_proxy.rebuild)
 
+        controller.was_reset.connect(left_view.expandAll)
+        controller.was_validated.connect(left_view.expandAll)
+        controller.was_published.connect(left_view.expandAll)
+        controller.was_acted.connect(left_view.expandAll)
+        controller.finished.connect(left_view.expandAll)
+
         controller.was_reset.connect(right_proxy.rebuild)
         controller.was_validated.connect(right_proxy.rebuild)
         controller.was_published.connect(right_proxy.rebuild)
         controller.was_acted.connect(right_proxy.rebuild)
         controller.finished.connect(right_proxy.rebuild)
+
+        controller.was_reset.connect(right_view.expandAll)
+        controller.was_validated.connect(right_view.expandAll)
+        controller.was_published.connect(right_view.expandAll)
+        controller.was_acted.connect(right_view.expandAll)
+        controller.finished.connect(right_view.expandAll)
 
         # Discovery happens synchronously during reset, that's
         # why it's important that this connection is triggered

--- a/pyblish_lite/window.py
+++ b/pyblish_lite/window.py
@@ -363,7 +363,10 @@ class Window(QtWidgets.QDialog):
         left_proxy.set_group_role(model.Families)
         left_view.setModel(left_proxy)
 
-        right_view.setModel(plugin_model)
+        right_proxy = tree.Proxy()
+        right_proxy.setSourceModel(plugin_model)
+        right_proxy.set_group_role(model.Order)
+        right_view.setModel(right_proxy)
         terminal_view.setModel(terminal_model)
 
         instance_combo.setModel(instance_model)
@@ -500,6 +503,12 @@ class Window(QtWidgets.QDialog):
         controller.was_published.connect(left_proxy.rebuild)
         controller.was_acted.connect(left_proxy.rebuild)
         controller.finished.connect(left_proxy.rebuild)
+
+        controller.was_reset.connect(right_proxy.rebuild)
+        controller.was_validated.connect(right_proxy.rebuild)
+        controller.was_published.connect(right_proxy.rebuild)
+        controller.was_acted.connect(right_proxy.rebuild)
+        controller.finished.connect(right_proxy.rebuild)
 
         # Discovery happens synchronously during reset, that's
         # why it's important that this connection is triggered

--- a/pyblish_lite/window.py
+++ b/pyblish_lite/window.py
@@ -363,7 +363,7 @@ class Window(QtWidgets.QDialog):
         left_proxy.set_group_role(model.Families)
         left_view.setModel(left_proxy)
 
-        right_proxy = tree.Proxy()
+        right_proxy = tree.PluginOrderGroupProxy()
         right_proxy.setSourceModel(plugin_model)
         right_proxy.set_group_role(model.Order)
         right_view.setModel(right_proxy)

--- a/pyblish_lite/window.py
+++ b/pyblish_lite/window.py
@@ -42,7 +42,7 @@ Todo:
 
 from Qt import QtCore, QtWidgets, QtGui
 
-from . import model, view, util, delegate
+from . import model, view, util, delegate, tree
 from .awesome import tags as awesome
 
 
@@ -133,8 +133,8 @@ class Window(QtWidgets.QDialog):
 
         overview_page = QtWidgets.QWidget()
 
-        left_view = view.Item()
-        right_view = view.Item()
+        left_view = tree.View()
+        right_view = tree.View()
 
         item_delegate = delegate.Item()
         left_view.setItemDelegate(item_delegate)
@@ -357,7 +357,12 @@ class Window(QtWidgets.QDialog):
         terminal_model = model.Terminal()
 
         artist_view.setModel(instance_model)
-        left_view.setModel(instance_model)
+
+        left_proxy = tree.Proxy()
+        left_proxy.setSourceModel(instance_model)
+        left_proxy.set_group_role(model.Families)
+        left_view.setModel(left_proxy)
+
         right_view.setModel(plugin_model)
         terminal_view.setModel(terminal_model)
 
@@ -489,6 +494,12 @@ class Window(QtWidgets.QDialog):
         controller.was_published.connect(self.on_was_published)
         controller.was_acted.connect(self.on_was_acted)
         controller.finished.connect(self.on_finished)
+
+        controller.was_reset.connect(left_proxy.rebuild)
+        controller.was_validated.connect(left_proxy.rebuild)
+        controller.was_published.connect(left_proxy.rebuild)
+        controller.was_acted.connect(left_proxy.rebuild)
+        controller.finished.connect(left_proxy.rebuild)
 
         # Discovery happens synchronously during reset, that's
         # why it's important that this connection is triggered


### PR DESCRIPTION
Experimental implementation for creating section headers as described in #21.

This implements a GroupByProxy that can group a (flat list) Model by a data role into a tree of sections and the original items.
Additionally this changes the `QListView` over to a `QTreeView` to retrieve the nesting functionality for the visuals.
