### PR TITLE
Fix #67, was_finished emitted on finishing anything

### DIFF
--- a/pyblish_lite/control.py
+++ b/pyblish_lite/control.py
@@ -35,7 +35,7 @@ class Controller(QtCore.QObject):
     was_acted = QtCore.Signal(dict)
 
     # Emitted when processing has finished
-    finished = QtCore.Signal()
+    was_finished = QtCore.Signal()
 
     def __init__(self, parent=None):
         super(Controller, self).__init__(parent)
@@ -150,7 +150,7 @@ class Controller(QtCore.QObject):
 
         def on_next():
             if self.current_pair == (None, None):
-                return util.defer(100, on_finished)
+                return util.defer(100, on_finished_)
 
             # The magic number 0.5 is the range between
             # the various CVEI processing stages;
@@ -162,7 +162,7 @@ class Controller(QtCore.QObject):
             #
             order = self.current_pair[0].order
             if order > (until + 0.5):
-                return util.defer(100, on_finished)
+                return util.defer(100, on_finished_)
 
             self.about_to_process.emit(*self.current_pair)
 
@@ -194,7 +194,7 @@ class Controller(QtCore.QObject):
             except StopIteration:
                 # All pairs were processed successfully!
                 self.current_pair = (None, None)
-                return util.defer(500, on_finished)
+                return util.defer(500, on_finished_)
 
             except Exception as e:
                 # This is a bug
@@ -208,7 +208,11 @@ class Controller(QtCore.QObject):
         def on_unexpected_error(error):
             self.warning("An unexpected error occurred; "
                          "see Terminal for more.")
-            return util.defer(500, on_finished)
+            return util.defer(500, on_finished_)
+
+        def on_finished_():
+            on_finished()
+            self.was_finished.emit()
 
         self.is_running = True
         util.defer(10, on_next)

--- a/pyblish_lite/version.py
+++ b/pyblish_lite/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 0
 VERSION_MINOR = 6
-VERSION_PATCH = 1
+VERSION_PATCH = 2
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info

--- a/pyblish_lite/window.py
+++ b/pyblish_lite/window.py
@@ -488,7 +488,7 @@ class Window(QtWidgets.QDialog):
         controller.was_validated.connect(self.on_was_validated)
         controller.was_published.connect(self.on_was_published)
         controller.was_acted.connect(self.on_was_acted)
-        controller.finished.connect(self.on_finished)
+        controller.was_finished.connect(self.on_finished)
 
         # Discovery happens synchronously during reset, that's
         # why it's important that this connection is triggered


### PR DESCRIPTION
#67 

This also **renames** the (previously unused) `finished` signal to `was_finished` to better align with surrounding signals.

`was_finished` is emitted after finishing anything; including reset, validated and published.

See here for exact logic.

```python

    count = {
        "was_reset": 0,
        "was_validated": 0,
        "was_published": 0,
        "was_finished": 0,
    }

    def on_signal(signal):
        count[signal] += 1

    ctrl = control.Controller()

    ctrl.was_reset.connect(lambda: on_signal("was_reset"))
    ctrl.was_validated.connect(lambda: on_signal("was_validated"))
    ctrl.was_published.connect(lambda: on_signal("was_published"))
    ctrl.was_finished.connect(lambda: on_signal("was_finished"))

    ctrl.reset()

    assert_equals(count, {
        "was_reset": 1,
        "was_validated": 0,
        "was_published": 0,
        "was_finished": 1,
    })

    ctrl.validate()

    assert_equals(count, {
        "was_reset": 1,
        "was_validated": 1,
        "was_published": 0,
        "was_finished": 2,
    })

    ctrl.publish()

    assert_equals(count, {
        "was_reset": 1,
        "was_validated": 1,
        "was_published": 1,
        "was_finished": 3,
    })

```