### PR TITLE
Make was_* signals synchronous

### DIFF
--- a/pyblish_lite/control.py
+++ b/pyblish_lite/control.py
@@ -95,7 +95,6 @@ class Controller(QtCore.QObject):
         util.defer(100, on_next)
 
     def emit_(self, signal, kwargs):
-
         pyblish.api.emit(signal, **kwargs)
 
     def _load(self):

--- a/pyblish_lite/version.py
+++ b/pyblish_lite/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 0
 VERSION_MINOR = 6
-VERSION_PATCH = 2
+VERSION_PATCH = 3
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info

--- a/pyblish_lite/window.py
+++ b/pyblish_lite/window.py
@@ -784,7 +784,7 @@ class Window(QtWidgets.QDialog):
         self.on_tab_changed(self.data["tabs"]["current"])
 
         self.controller.current_error = None
-        util.defer(500, self.on_finished)
+        self.on_finished()
 
     def on_was_validated(self):
         plugin_model = self.data["models"]["plugins"]
@@ -801,7 +801,7 @@ class Window(QtWidgets.QDialog):
         buttons["play"].show()
         buttons["stop"].hide()
 
-        util.defer(500, self.on_finished)
+        self.on_finished()
 
     def on_was_published(self):
         plugin_model = self.data["models"]["plugins"]
@@ -820,7 +820,7 @@ class Window(QtWidgets.QDialog):
         comment_box = self.findChild(QtWidgets.QWidget, "CommentBox")
         comment_box.hide()
 
-        util.defer(500, self.on_finished)
+        self.on_finished()
 
     def on_was_processed(self, result):
         models = self.data["models"]


### PR DESCRIPTION
Now when these signals are emitted, the GUI is in a finished state, allowing for example closing of the GUI upon receiving the was_published signal; if this is all that they GUI was meant to do.

```python
# Replace `Qt` with your binding, e.g. PySide2
from Qt import QtCore
import pyblish_lite

def on_published():
  QtCore.QTimer.singleShot(10, window.close)

window = pyblish_lite.show()
window.controller.was_published.connect(on_published)
```

**Under the hood**

One thing to note is the use of `QTimer`. Why not just call `close` right away? Well, `was_published` is still a signal and you are not alone in listening to it. Another factor is the window being alerted of the fact that it is now safe to close.

If your signal runs first (the order or operations on signals are, to my knowledge, non-deterministic) then the Window would unaware of completion once you ask it to close.

Delaying the call to `close`, via a `QTimer`, will guarantee that all signals currently in the queue will evaluate first. You could potentially even set the timer threshold to `0`, given the fact that queues themselves are in fact, to my knowledge, deterministic; i.e. processed one after the other in the order they were created.

**Caveat**

The thing to look out for in this version is expensive post-processes right after finishing validation. Because whatever post-processes are now run instantly upon completion, the GUI could potentially stall until the post-processes are completed, *before* having had time to update the graphics; i.e. the color of processed items in the view - giving you the impression that it permanently stalled.

In practice, this should not be noticeable. But keep an eye out, and let me know if you experience any issues.