### PR TITLE
Fix for #60 and #61

### DIFF
--- a/pyblish_lite/model.py
+++ b/pyblish_lite/model.py
@@ -308,7 +308,11 @@ class Plugin(Item):
         self.setData(index, False, IsProcessing)
         self.setData(index, True, HasProcessed)
         self.setData(index, result["success"], HasSucceeded)
-        self.setData(index, not result["success"], HasFailed)
+
+        # Once failed, never go back.
+        if not self.data(index, HasFailed):
+            self.setData(index, not result["success"], HasFailed)
+
         super(Plugin, self).update_with_result(result)
 
 
@@ -383,7 +387,11 @@ class Instance(Item):
         self.setData(index, False, IsProcessing)
         self.setData(index, True, HasProcessed)
         self.setData(index, result["success"], HasSucceeded)
-        self.setData(index, not result["success"], HasFailed)
+
+        # Once failed, never go back.
+        if not self.data(index, HasFailed):
+            self.setData(index, not result["success"], HasFailed)
+
         super(Instance, self).update_with_result(result)
 
 

--- a/pyblish_lite/version.py
+++ b/pyblish_lite/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 0
 VERSION_MINOR = 6
-VERSION_PATCH = 3
+VERSION_PATCH = 4
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
Problem was as expected where if an Instance or Plugin had failed, and then succeeded, the failed state got overwritten with the newest succceded state.
Solution was to never go back from a failed state, and implemented by only updating the failed state if the Instance/Plugin hasn't already failed.