### PR TITLE
Add instance after each plugin process.

### DIFF
--- a/pyblish_lite/model.py
+++ b/pyblish_lite/model.py
@@ -408,6 +408,7 @@ class Instance(Item):
 
         super(Instance, self).update_with_result(result)
 
+
 class Terminal(Abstract):
     def __init__(self, parent=None):
         super(Terminal, self).__init__(parent)

--- a/pyblish_lite/model.py
+++ b/pyblish_lite/model.py
@@ -325,6 +325,7 @@ class Instance(Item):
     def __init__(self):
         super(Instance, self).__init__()
 
+        self.ids = []
         self.schema.update({
             IsChecked: "publish",
 
@@ -340,6 +341,9 @@ class Instance(Item):
         # Use instance name if settings say so.
         if not settings.UseLabel:
             item.data["label"] = item.data["name"]
+
+        # Store instances id in easy access data member
+        self.ids.append(item.id)
 
         # GUI-only data
         item.data["_type"] = "instance"
@@ -392,6 +396,7 @@ class Instance(Item):
 
         index = self.items.index(item)
         index = self.createIndex(index, 0)
+
         self.setData(index, False, IsIdle)
         self.setData(index, False, IsProcessing)
         self.setData(index, True, HasProcessed)
@@ -402,7 +407,6 @@ class Instance(Item):
             self.setData(index, not result["success"], HasFailed)
 
         super(Instance, self).update_with_result(result)
-
 
 class Terminal(Abstract):
     def __init__(self, parent=None):

--- a/pyblish_lite/version.py
+++ b/pyblish_lite/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 0
 VERSION_MINOR = 7
-VERSION_PATCH = 0
+VERSION_PATCH = 1
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info

--- a/pyblish_lite/window.py
+++ b/pyblish_lite/window.py
@@ -874,6 +874,9 @@ class Window(QtWidgets.QDialog):
         models["instances"].store_checkstate()
         models["plugins"].store_checkstate()
 
+        # Reset current ids to secure no previous instances get mixed in.
+        models["instances"].ids = []
+
         for m in models.values():
             m.reset()
 

--- a/pyblish_lite/window.py
+++ b/pyblish_lite/window.py
@@ -756,9 +756,6 @@ class Window(QtWidgets.QDialog):
     def on_was_reset(self):
         models = self.data["models"]
 
-        for instance in self.controller.context:
-            models["instances"].append(instance)
-
         self.info("Finishing up reset..")
 
         buttons = self.data["buttons"]
@@ -824,6 +821,10 @@ class Window(QtWidgets.QDialog):
 
     def on_was_processed(self, result):
         models = self.data["models"]
+
+        for instance in self.controller.context:
+            if instance.id not in models["instances"].ids:
+                models["instances"].append(instance)
 
         models["plugins"].update_with_result(result)
         models["instances"].update_with_result(result)

--- a/pyblish_lite/window.py
+++ b/pyblish_lite/window.py
@@ -758,6 +758,10 @@ class Window(QtWidgets.QDialog):
 
         self.info("Finishing up reset..")
 
+        models["instances"].reset()
+        for instance in self.controller.context:
+            models["instances"].append(instance)
+
         buttons = self.data["buttons"]
         buttons["play"].show()
         buttons["validate"].show()


### PR DESCRIPTION
This fixes #78 and #74.

The problem was as @BigRoy pointed out, that the instances are first added to the model after collection. This results in that we can't access instances during collection.

I could have done all the id comparing in the ```on_was_processed``` method, but thought it might be quicker to store the data in the model. Hopefully also keeps the data where it should be (?).