### PR TITLE
Hides plugins with no members of theire families collected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ dist
 cover
 .coverage
 build
+.idea/misc.xml
+.idea/modules.xml
+.idea/pyblish-lite.iml
+.idea/vcs.xml
+.idea/workspace.xml

--- a/pyblish_lite/version.py
+++ b/pyblish_lite/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 0
 VERSION_MINOR = 7
-VERSION_PATCH = 1
+VERSION_PATCH = 2
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info

--- a/pyblish_lite/window.py
+++ b/pyblish_lite/window.py
@@ -714,7 +714,6 @@ class Window(QtWidgets.QDialog):
         index = plugin_model.items.index(plugin)
         index = plugin_model.createIndex(index, 0)
         plugin_model.setData(index, True, model.IsProcessing)
-        # self.data["models"]["plugins"].items[1].families
         self.info("Processing %s" % (index.data(model.Label)))
 
     def on_plugin_action_menu_requested(self, pos):
@@ -831,16 +830,16 @@ class Window(QtWidgets.QDialog):
             if instance.id not in models["instances"].ids:
                 models["instances"].append(instance)
 
-            family = instance.data['family']
+            family = instance.data["family"]
             if family:
-                plugins_filter = self.data['views']['right'].model()
-                plugins_filter.add_inclusion(role='families', value=family)
+                plugins_filter = self.data["views"]["right"].model()
+                plugins_filter.add_inclusion(role="families", value=family)
 
-            families = instance.data['families'] if 'families' in instance.data  else False
+            families = instance.data.get("families")
             if families:
                 for f in families:
-                    plugins_filter = self.data['views']['right'].model()
-                    plugins_filter.add_inclusion(role='families', value=f)
+                    plugins_filter = self.data["views"]["right"].model()
+                    plugins_filter.add_inclusion(role="families", value=f)
 
         models["plugins"].update_with_result(result)
         models["instances"].update_with_result(result)
@@ -885,9 +884,8 @@ class Window(QtWidgets.QDialog):
         """Prepare GUI for reset"""
         self.info("About to reset..")
 
-        plugins_filter = self.data['views']['right'].model()
+        plugins_filter = self.data["views"]["right"].model()
         plugins_filter.clear_inclusion()
-        plugins_filter.add_inclusion(role='families', value="*")
 
         models = self.data["models"]
 

--- a/pyblish_lite/window.py
+++ b/pyblish_lite/window.py
@@ -358,7 +358,8 @@ class Window(QtWidgets.QDialog):
 
         artist_view.setModel(instance_model)
         left_view.setModel(instance_model)
-        right_view.setModel(plugin_model)
+        plugins_filter = model.ProxyModel(plugin_model)
+        right_view.setModel(plugins_filter)
         terminal_view.setModel(terminal_model)
 
         instance_combo.setModel(instance_model)
@@ -713,7 +714,7 @@ class Window(QtWidgets.QDialog):
         index = plugin_model.items.index(plugin)
         index = plugin_model.createIndex(index, 0)
         plugin_model.setData(index, True, model.IsProcessing)
-
+        # self.data["models"]["plugins"].items[1].families
         self.info("Processing %s" % (index.data(model.Label)))
 
     def on_plugin_action_menu_requested(self, pos):
@@ -830,6 +831,17 @@ class Window(QtWidgets.QDialog):
             if instance.id not in models["instances"].ids:
                 models["instances"].append(instance)
 
+            family = instance.data['family']
+            if family:
+                plugins_filter = self.data['views']['right'].model()
+                plugins_filter.add_inclusion(role='families', value=family)
+
+            families = instance.data['families'] if 'families' in instance.data  else False
+            if families:
+                for f in families:
+                    plugins_filter = self.data['views']['right'].model()
+                    plugins_filter.add_inclusion(role='families', value=f)
+
         models["plugins"].update_with_result(result)
         models["instances"].update_with_result(result)
         models["terminal"].update_with_result(result)
@@ -873,6 +885,10 @@ class Window(QtWidgets.QDialog):
         """Prepare GUI for reset"""
         self.info("About to reset..")
 
+        plugins_filter = self.data['views']['right'].model()
+        plugins_filter.clear_inclusion()
+        plugins_filter.add_inclusion(role='families', value="*")
+
         models = self.data["models"]
 
         models["instances"].store_checkstate()
@@ -894,7 +910,6 @@ class Window(QtWidgets.QDialog):
 
     def validate(self):
         self.info("Preparing validate..")
-
         for button in self.data["buttons"].values():
             button.hide()
 


### PR DESCRIPTION
That's a small change that may be useful: I've modified the QProxyFilterModel and applied it to the plugins list on the right, so the plugins without any family members collected are hiden