### PR TITLE
Attempt to fix issue #59

### DIFF
--- a/pyblish_lite/control.py
+++ b/pyblish_lite/control.py
@@ -163,6 +163,12 @@ class Controller(QtCore.QObject):
             if order > (until + 0.5):
                 return util.defer(100, on_finished_)
 
+            plug, instance = self.current_pair
+            if not plug.active or \
+                (instance is not None and instance.data.get("publish") is False):
+                util.defer(10, try_next)
+                return
+
             self.about_to_process.emit(*self.current_pair)
 
             util.defer(10, on_process)
@@ -187,6 +193,9 @@ class Controller(QtCore.QObject):
             # IMPORTANT: This *must* be done *after* processing of
             # the current pair, otherwise data generated at that point
             # will *not* be included.
+            try_next()
+
+        def try_next():
             try:
                 self.current_pair = next(self.pair_generator)
 
@@ -227,11 +236,10 @@ class Controller(QtCore.QObject):
         test = pyblish.logic.registered_test()
 
         for plug, instance in pyblish.logic.Iterator(plugins, context):
-            if not plug.active:
-                continue
 
-            if instance is not None and instance.data.get("publish") is False:
-                continue
+            # We do not care about checking the plugin or instance "active" states
+            # because it can change outside of this "for" loop, so any checks here
+            # could potentially be outdated or inaccurate.
 
             self.processing["nextOrder"] = plug.order
 

--- a/pyblish_lite/window.py
+++ b/pyblish_lite/window.py
@@ -493,7 +493,7 @@ class Window(QtWidgets.QDialog):
         controller.was_validated.connect(self.on_was_validated)
         controller.was_published.connect(self.on_was_published)
         controller.was_acted.connect(self.on_was_acted)
-        controller.was_finished.connect(self.on_finished)
+        # controller.was_finished.connect(self.on_finished)
 
         # Discovery happens synchronously during reset, that's
         # why it's important that this connection is triggered


### PR DESCRIPTION
This is not really working quite right yet, but I'm giving it a try. Advice, corrections, tips all welcome.


This is my testing scenario which generates `potato_0` through `potato_3` and only the last one is activated:
```python
import pyblish.api
import pyblish_lite


class FakeCollector(pyblish.api.ContextPlugin):
    order = pyblish.api.CollectorOrder

    def process(self, context):
        for i in range(4):
            name = 'potato_{0}'.format(i)
            inst = context.create_instance(
                name, label=name, family='vegetable')
            inst.data['icon'] = 'male'
            inst.data['optional'] = True

            # Leave them all OFF except the last one:
            inst.data['publish'] = name == 'potato_3'


class FakeValidator(pyblish.api.InstancePlugin):
    order = pyblish.api.ValidatorOrder
    families = ['vegetable']

    def process(self, instance):
        # raise pyblish.api.ValidationError('Boo!')
        pass


def setupPlugins():
    pyblish.api.deregister_all_plugins()
    pyblish.api.deregister_all_paths()
    pyblish.api.register_plugin(FakeCollector)
    pyblish.api.register_plugin(FakeValidator)


def startUI():
    setupPlugins()
    pyblish.api.register_host("python")
    window = pyblish_lite.show()


startUI()
```

Previous to this PR, if you untick `potato_3` and tick any of the others, potato_3 will get a green outline, meaning it processed, despite being deactivated.

With the code as it stands at the moment, if I uncheck `potato_3`, it does not get evaluated, but neither does the others. It seems I made the whole FakeValidator skip instead of the individual instance. I must've done something wrong somewhere.
