### PR TITLE
Fix warning color only displayed if last instance has a warning

### DIFF
--- a/pyblish_lite/model.py
+++ b/pyblish_lite/model.py
@@ -311,7 +311,9 @@ class Plugin(Item):
 
         index = self.items.index(item)
         index = self.createIndex(index, 0)
-        hasWarning = any([record.levelno == logging.WARNING for record in result["records"]])
+        hasWarning = self.data(index, HasWarning)
+        if not hasWarning:
+            hasWarning = any([record.levelno == logging.WARNING for record in result["records"]])
 
         self.setData(index, False, IsIdle)
         self.setData(index, False, IsProcessing)

--- a/pyblish_lite/version.py
+++ b/pyblish_lite/version.py
@@ -2,7 +2,7 @@
 VERSION_MAJOR = 0
 VERSION_MINOR = 8
 VERSION_PATCH = 8
-VERSION_BETA = "b1"
+VERSION_BETA = "b2"
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH, VERSION_BETA)
 version = '%i.%i.%i%s' % version_info


### PR DESCRIPTION
This is a fix for a bug where the warning color is not displayed next to plugins in which a warning was logged for some instances but not the last executed one.

When logging a warning in an `InstancePlugin`, the UI reacts by coloring the little square as orange next to the plugin's label. However, this behavior only works if the last instance to be executed has a warning logged. If there are 3 instances and a warning is logged only for the first instance, then the little square will be displayed as green, as if there was no warning at all.

The fix is to simply check in the model's `hasWarning` data to see if a warning was previously set, and if so, then keep it that way.