### PR TITLE
Fix missing "failed" actions on plugins with warnings instead of errors

### DIFF
--- a/pyblish_lite/model.py
+++ b/pyblish_lite/model.py
@@ -226,6 +226,10 @@ class Plugin(Item):
             for action in actions:
                 if action.on == "failed" and item._has_failed:
                     return True
+                if action.on == "warning" and item._has_warning:
+                    return True
+                if action.on == "failedOrWarning" and (item._has_failed or item._has_warning):
+                    return True
                 if action.on == "succeeded" and item._has_succeeded:
                     return True
                 if action.on == "processed" and item._has_processed:
@@ -246,6 +250,10 @@ class Plugin(Item):
             # Context specific actions
             for action in actions[:]:
                 if action.on == "failed" and not item._has_failed:
+                    actions.remove(action)
+                if action.on == "warning" and not item._has_warning:
+                    actions.remove(action)
+                if action.on == "failedOrWarning" and not (item._has_failed or item._has_warning):
                     actions.remove(action)
                 if action.on == "succeeded" and not item._has_succeeded:
                     actions.remove(action)

--- a/pyblish_lite/version.py
+++ b/pyblish_lite/version.py
@@ -2,7 +2,7 @@
 VERSION_MAJOR = 0
 VERSION_MINOR = 8
 VERSION_PATCH = 8
-VERSION_BETA = "b2"
+VERSION_BETA = "b3"
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH, VERSION_BETA)
 version = '%i.%i.%i%s' % version_info


### PR DESCRIPTION
When plugins have warnings instead of errors, they are not considered for the available "failed" actions.

I thought there'd be 2 ways to handle this case:
1) Assume that plugins with either warnings or error have failed, and therefore use the same `on` action type: "failed".
2) Create a new `on` action type, "warning", in pyblish_base, and add support for warnings the core pyblish_base API instead of just pyblish-lite.

The second option seemed like it would be a lot more work, as warnings seem to currently only be supported in pyblish-lite itself, so I worked on the easier first option. Besides, I thought it made sense that warnings and errors would use the same action to be fixed, as the plugin identifies an issue and that issue is either critical or not, but the way to fix it should be with the same action in both cases.

Let me know what you think @mottosso !