### PR TITLE
Add icon visibility for actions enabled on "all"

### DIFF
--- a/pyblish_lite/model.py
+++ b/pyblish_lite/model.py
@@ -224,6 +224,8 @@ class Plugin(Item):
 
             # Context specific actions
             for action in actions:
+                if action.on == "all":
+                    return True
                 if action.on == "failed" and item._has_failed:
                     return True
                 if action.on == "warning" and item._has_warning:


### PR DESCRIPTION
This fixes issue #84.
Icons for actions enabled `on = "all"` are made visible.

As commented in the issue, the bug might have been introduced here https://github.com/pyblish/pyblish-lite/commit/3c86cd6a06bda151853834ecd642d31abb6863cf#diff-4e27d04248feb2897be1066c5a0234cb332f4a7029aa1d33255b9c5f75837e72L231
as before the icons visibility was on by default.

I was hesitant to change the default visibility, because I found it hard to test for all the possibilities.
Because of that, I explicitly added visibility for the on "all" actions.

Please let me know what you think. 