### PR TITLE
Fix use environment variable to set `PYTHONIOENCODING` 

### DIFF
--- a/pyblish_lite/util.py
+++ b/pyblish_lite/util.py
@@ -59,11 +59,11 @@ def u_print(msg, **kwargs):
     """
 
     if isinstance(msg, text_type):
-        encoding = None
         try:
-            encoding = os.getenv('PYTHONIOENCODING', sys.stdout.encoding)
+            encoding = sys.stdout.encoding
         except AttributeError:
             # `sys.stdout.encoding` may not exists.
-            pass
+            encoding = None
+        encoding = os.getenv('PYTHONIOENCODING', encoding)
         msg = msg.encode(encoding or 'utf-8', 'replace')
     print(msg, **kwargs)

--- a/pyblish_lite/version.py
+++ b/pyblish_lite/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 0
 VERSION_MINOR = 8
-VERSION_PATCH = 12
+VERSION_PATCH = 13
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
Hi, this PR just fix the use environment variable to set `PYTHONIOENCODING` in Maya.

Since executing `sys.stdout.encoding` in Maya will prompt `AttributeError` so `encoding` will always be `None`
![image](https://user-images.githubusercontent.com/13111745/191672614-ab532837-2a7f-4aa4-b5ab-d12db9d176f8.png)
