### PR TITLE
Add new env to disable string encodeing

### DIFF
--- a/pyblish_lite/util.py
+++ b/pyblish_lite/util.py
@@ -57,13 +57,13 @@ def u_print(msg, **kwargs):
         msg (unicode): Message to print.
         **kwargs: Keyword argument for `print` function.
     """
-
-    if isinstance(msg, text_type):
-        try:
-            encoding = sys.stdout.encoding
-        except AttributeError:
-            # `sys.stdout.encoding` may not exists.
-            encoding = None
-        encoding = os.getenv('PYTHONIOENCODING', encoding)
-        msg = msg.encode(encoding or 'utf-8', 'replace')
+    if os.getenv('PYBLISH_DISABLE_IO_ENCODING', 'no').lower() != 'yes':
+        if isinstance(msg, text_type):
+            try:
+                encoding = sys.stdout.encoding
+            except AttributeError:
+                # `sys.stdout.encoding` may not exists.
+                encoding = None
+            encoding = os.getenv('PYTHONIOENCODING', encoding)
+            msg = msg.encode(encoding or 'utf-8', 'replace')
     print(msg, **kwargs)

--- a/pyblish_lite/util.py
+++ b/pyblish_lite/util.py
@@ -59,11 +59,11 @@ def u_print(msg, **kwargs):
     """
 
     if isinstance(msg, text_type):
-        encoding = None
         try:
-            encoding = os.getenv('PYTHONIOENCODING', sys.stdout.encoding)
+            encoding = sys.stdout.encoding
         except AttributeError:
             # `sys.stdout.encoding` may not exists.
-            pass
+            encoding = None
+        encoding = os.getenv('PYTHONIOENCODING', encoding)
         msg = msg.encode(encoding or 'utf-8', 'replace')
     print(msg, **kwargs)

--- a/pyblish_lite/version.py
+++ b/pyblish_lite/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 0
-VERSION_MINOR = 8
-VERSION_PATCH = 13
+VERSION_MINOR = 9
+VERSION_PATCH = 0
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info

--- a/pyblish_lite/version.py
+++ b/pyblish_lite/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 0
 VERSION_MINOR = 8
-VERSION_PATCH = 12
+VERSION_PATCH = 13
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
This PR wants to add a new environment variable `PYBLISH_DISABLE_IO_ENCODING` to disable string encoding

Since our system language is Chinese, even if the interface language of Maya is English, we can directly print out Chinese characters. If we encode print using `uft-8` in this case, garbled characters will appear.

maya-2022 (python-3.7)
![image](https://user-images.githubusercontent.com/13111745/191705454-99186df4-818c-4936-9ae9-ced03c7a92f3.png)

maya-2020 (python-2.7)
![image](https://user-images.githubusercontent.com/13111745/191705527-e54b81b9-5dea-42b6-8813-41391d2fe421.png)

