### PR TITLE
Fix issue with PySide6

### DIFF
--- a/pyblish_lite/app.py
+++ b/pyblish_lite/app.py
@@ -85,7 +85,7 @@ def show(parent=None):
         font = self._window.font()
         font.setFamily("Open Sans")
         font.setPointSize(8)
-        font.setWeight(400)
+        font.setWeight(QtGui.QFont.Normal)
 
         self._window.setFont(font)
         self._window.setStyleSheet(css)


### PR DESCRIPTION
This PR fixes:

```
# Error: TypeError: file \pyblish-lite\pyblish_lite\app.py line 88: 'PySide6.QtGui.QFont.setWeight' called with wrong argument types:
#   PySide6.QtGui.QFont.setWeight(int)
# Supported signatures:
#   PySide6.QtGui.QFont.setWeight(PySide6.QtGui.QFont.Weight)
```

still works with PySide5 as well