### PR TITLE
fix PySide6 porting

### DIFF
--- a/pyblish_lite/view.py
+++ b/pyblish_lite/view.py
@@ -50,7 +50,7 @@ class Item(QtWidgets.QListView):
         super(Item, self).leaveEvent(event)
 
     def mousePressEvent(self, event):
-        if event.button() == QtCore.Qt.MidButton:
+        if event.button() == QtCore.Qt.MiddleButton:
             index = self.indexAt(event.pos())
             self.inspected.emit(index) if index.isValid() else None
 
@@ -81,7 +81,7 @@ class LogView(QtWidgets.QListView):
         self.setVerticalScrollMode(QtWidgets.QListView.ScrollPerPixel)
 
     def mousePressEvent(self, event):
-        if event.button() == QtCore.Qt.MidButton:
+        if event.button() == QtCore.Qt.MiddleButton:
             index = self.indexAt(event.pos())
             self.inspected.emit(index) if index.isValid() else None
 


### PR DESCRIPTION
Qt.MidButton has been renamed to Qt.MiddleButton in PySide6